### PR TITLE
feat: MCP server infrastructure — dual-transport entry point and handler stubs (#8)

### DIFF
--- a/docs/features/mcp-server-infrastructure/spec.md
+++ b/docs/features/mcp-server-infrastructure/spec.md
@@ -1,0 +1,276 @@
+# Feature Spec: MCP Server Infrastructure — stdio + Streamable HTTP Transports
+
+**ID**: FEAT-0008
+**Status**: Draft
+**Author**: GitHub Copilot
+**Created**: 2026-04-20
+**Last Updated**: 2026-04-20
+**GitHub Issue**: [#8 — Feature: MCP stdio Transport](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/8)
+**Parent Epic**: [#1 — Core MCP Server](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/1)
+**Related ADRs**:
+[ADR-0001](../../architecture/decisions/ADR-0001-mcp-sdk-selection.md),
+[ADR-0002](../../architecture/decisions/ADR-0002-solution-structure.md),
+[ADR-0005](../../architecture/decisions/ADR-0005-ihttpclientfactory-typed-client.md)
+
+---
+
+## Executive Summary
+
+- **Objective**: Wire up the MCP server entry point with full dependency injection composition, stub tool and resource registration, and dual-transport support (stdio and Streamable HTTP), giving all downstream tool and resource implementations a runnable host.
+- **Primary user**: MCP clients — Claude Desktop (via stdio) and web/network agents (via Streamable HTTP).
+- **Value delivered**: A connectable MCP server that completes the `initialize` handshake, returns all registered tool and resource descriptors from `tools/list` and `resources/list`, and shuts down gracefully — unblocking all subsequent tool and resource feature implementations (#7, #9, #16, #6, #12, #10).
+- **Scope**: `Program.cs` composition root, `Server.cs` tool/resource registration, transport selection logic, DI wiring, stub handler scaffolding, graceful shutdown, and startup error handling. No actual tool or resource business logic is in scope.
+- **Primary success criterion**: `dotnet run` completes the MCP `initialize` handshake over stdio and `tools/list` returns all registered stub tool descriptors without error.
+
+---
+
+## Problem Statement
+
+The repository has a compilable solution (FEAT-0014) and a fully implemented BookStack API client (FEAT-0018), but no `Program.cs` composition root that wires these together and exposes them over the Model Context Protocol (MCP). Without a running server entry point and tool/resource registration, no MCP client can connect, and all downstream implementations (#7, #9, #16, #6, #12, #10) have no host to attach to. The critical path is blocked until this feature is complete.
+
+## Goals
+
+1. Provide a `Program.cs` composition root using the .NET Generic Host that configures the dependency injection (DI) container, selects the active transport, and starts the MCP server.
+2. Provide a `Server.cs` (or equivalent) that registers all tool and resource handler stubs with the `ModelContextProtocol` SDK, so that `tools/list` and `resources/list` return complete descriptors immediately.
+3. Support two transports — `stdio` (default, required for Claude Desktop and most MCP clients) and Streamable HTTP (for web/network scenarios) — selected via the `BOOKSTACK_MCP_TRANSPORT` environment variable.
+4. Handle SIGTERM and SIGINT for graceful shutdown so that in-flight requests complete before the process exits.
+5. Ensure all structured diagnostic output goes to stderr (never stdout), preventing MCP JSON-RPC frame corruption on the stdio transport.
+
+## Non-Goals
+
+- Implementing any MCP tool or resource business logic (deferred to #7, #9, #16, #6, #12, #10).
+- Configuring Transport Layer Security (TLS) or HTTPS for the Streamable HTTP transport.
+- Implementing request authentication or authorization for the HTTP transport endpoint.
+- Docker image or container packaging.
+- MCP prompts support.
+- Implementing a health-check HTTP endpoint.
+
+## Requirements
+
+### Functional Requirements
+
+1. `Program.cs` MUST use `IHostBuilder` / `IHost` from `Microsoft.Extensions.Hosting` as the sole composition root; no top-level `new` operators for injected services.
+2. `Program.cs` MUST call the `AddBookStackApiClient(IConfiguration)` extension method (from FEAT-0018) to register `IBookStackApiClient` and its delegating handlers.
+3. `Program.cs` MUST register the MCP server using the `ModelContextProtocol` SDK's `IServiceCollection` extension methods, with the server name set to `bookstack-mcp-server-dotnet` and the version read from the entry assembly.
+4. The transport MUST be selected at startup from the `BOOKSTACK_MCP_TRANSPORT` environment variable; valid values are `stdio` (default when the variable is absent or empty) and `http`.
+5. When `BOOKSTACK_MCP_TRANSPORT` is `stdio` or unset, the server MUST start using `StdioServerTransport` and route all `ILogger` output to stderr so that stdout carries only MCP JSON-RPC frames.
+6. When `BOOKSTACK_MCP_TRANSPORT` is `http`, the server MUST start Streamable HTTP transport via `ModelContextProtocol.AspNetCore` and listen on the port specified by `BOOKSTACK_MCP_HTTP_PORT` (default `3000`).
+7. An invalid `BOOKSTACK_MCP_TRANSPORT` value (any value other than `stdio` or `http`) MUST produce a structured error log and terminate the process with a non-zero exit code before the MCP handshake begins.
+8. `Server.cs` MUST register stub tool handler classes for all BookStack tool categories: books, chapters, pages, shelves, users, roles, attachments, images, search, recycle bin, content permissions, audit log, system info, and server info.
+9. `Server.cs` MUST register stub resource handler classes for all BookStack resource categories: books, chapters, pages, shelves, users, and search.
+10. `Program.cs` MUST wire SIGTERM and SIGINT to the `IHostApplicationLifetime.StopApplication()` method so that the Generic Host triggers graceful shutdown on either signal.
+11. All unhandled exceptions reaching the top-level `try`/`catch` in `Program.cs` MUST be logged via `ILogger<Program>` at `Critical` level and cause the process to exit with a non-zero exit code.
+12. Missing or invalid required configuration (`BookStack:TokenId`, `BookStack:TokenSecret`) MUST be detected at startup via `IOptionsMonitor<BookStackApiClientOptions>` validation and produce a clear structured error before the MCP handshake begins.
+13. All log output MUST use `ILogger<T>` structured logging; `Console.WriteLine` and `Console.Error.WriteLine` are prohibited in all production code paths.
+
+### Non-Functional Requirements
+
+1. Server startup — from `dotnet run` invocation to completion of the MCP `initialize` handshake — MUST complete within five seconds under normal conditions on the CI runner.
+2. The server MUST NOT write any non-MCP content to stdout when running in `stdio` mode; this is a protocol correctness requirement, not a quality-of-life concern.
+3. The DI container MUST be the sole mechanism for service resolution; `ServiceLocator` patterns and manual `new` construction of DI-registered services are prohibited.
+4. The solution MUST compile and run on .NET 10 (`net10.0`) without platform-specific conditional compilation directives.
+5. All async methods MUST accept a `CancellationToken` parameter and propagate it to every awaitable call.
+
+## Design
+
+### File Layout
+
+```
+src/BookStack.Mcp.Server/
+  Program.cs                          # Composition root — DI, transport selection, host start
+  Server.cs                           # Tool and resource registration with MCP SDK
+  tools/
+    books/BookToolHandler.cs          # Stub — [McpServerTool] decorated class
+    chapters/ChapterToolHandler.cs    # Stub
+    pages/PageToolHandler.cs          # Stub
+    shelves/ShelfToolHandler.cs       # Stub
+    users/UserToolHandler.cs          # Stub
+    roles/RoleToolHandler.cs          # Stub
+    attachments/AttachmentToolHandler.cs  # Stub
+    images/ImageToolHandler.cs        # Stub
+    search/SearchToolHandler.cs       # Stub
+    recyclebin/RecycleBinToolHandler.cs   # Stub
+    permissions/PermissionToolHandler.cs  # Stub
+    audit/AuditToolHandler.cs         # Stub
+    system/SystemToolHandler.cs       # Stub
+    server-info/ServerInfoToolHandler.cs  # Stub
+  resources/
+    books/BookResourceHandler.cs      # Stub — [McpServerResource] decorated class
+    chapters/ChapterResourceHandler.cs    # Stub
+    pages/PageResourceHandler.cs      # Stub
+    shelves/ShelfResourceHandler.cs   # Stub
+    users/UserResourceHandler.cs      # Stub
+    search/SearchResourceHandler.cs   # Stub
+```
+
+### Component Diagram
+
+```mermaid
+graph TD
+    A[MCP Client<br/>Claude Desktop / HTTP agent] -->|stdio or HTTP| B[Program.cs<br/>Generic Host]
+    B --> C[Server.cs<br/>Tool + Resource Registration]
+    C --> D[Tool Handlers<br/>stubs — 14 classes]
+    C --> E[Resource Handlers<br/>stubs — 6 classes]
+    D --> F[IBookStackApiClient<br/>FEAT-0018]
+    E --> F
+    F --> G[BookStack Instance]
+    H[IConfiguration<br/>env vars / appsettings.json] --> B
+    H --> F
+```
+
+### Startup Sequence — stdio Transport
+
+```mermaid
+sequenceDiagram
+    participant OS as OS / Shell
+    participant P  as Program.cs
+    participant H  as IHost
+    participant S  as Server.cs
+    participant T  as StdioServerTransport
+    participant C  as MCP Client
+
+    OS->>P: dotnet run
+    P->>P: Build IHostBuilder
+    P->>P: AddBookStackApiClient(config)
+    P->>P: AddMcpServer() + RegisterHandlers()
+    P->>H: host.StartAsync(ct)
+    H->>S: Register tool + resource descriptors
+    H->>T: Connect StdioServerTransport
+    T-->>C: (ready to receive)
+    C->>T: initialize request (JSON-RPC over stdin)
+    T-->>C: initialize response (stdout)
+    C->>T: tools/list
+    T-->>C: 47+ tool descriptors
+    OS->>P: SIGINT / SIGTERM
+    P->>H: host.StopAsync(ct)
+    H->>T: Close transport
+    P->>OS: exit 0
+```
+
+### Startup Sequence — Streamable HTTP Transport
+
+```mermaid
+sequenceDiagram
+    participant OS as OS / Shell
+    participant P  as Program.cs
+    participant W  as ASP.NET Core WebApp
+    participant T  as StreamableHttpTransport
+    participant C  as MCP Client (HTTP)
+
+    OS->>P: dotnet run (BOOKSTACK_MCP_TRANSPORT=http)
+    P->>P: Build WebApplicationBuilder
+    P->>P: AddBookStackApiClient(config)
+    P->>P: AddMcpServer() + RegisterHandlers()
+    P->>W: app.MapMcp()
+    W->>T: Listen on BOOKSTACK_MCP_HTTP_PORT
+    C->>W: POST /mcp (initialize)
+    W-->>C: initialize response
+    C->>W: POST /mcp (tools/list)
+    W-->>C: 47+ tool descriptors
+```
+
+### Configuration Reference
+
+| `IConfiguration` key              | Environment variable          | Required | Default   | Description                        |
+|-----------------------------------|-------------------------------|----------|-----------|------------------------------------|
+| `BookStack:BaseUrl`               | `BOOKSTACK_BASE_URL`          | No       | `http://localhost:8080` | BookStack instance URL  |
+| `BookStack:TokenId`               | `BOOKSTACK_TOKEN_ID`          | Yes      | —         | API token ID                       |
+| `BookStack:TokenSecret`           | `BOOKSTACK_TOKEN_SECRET`      | Yes      | —         | API token secret                   |
+| `BookStack:TimeoutSeconds`        | `BOOKSTACK_TIMEOUT_SECONDS`   | No       | `30`      | HTTP request timeout (seconds)     |
+| *(no IConfiguration key)*        | `BOOKSTACK_MCP_TRANSPORT`     | No       | `stdio`   | Transport: `stdio` or `http`       |
+| *(no IConfiguration key)*        | `BOOKSTACK_MCP_HTTP_PORT`     | No       | `3000`    | HTTP listen port (http transport)  |
+
+> **Note**: `BOOKSTACK_MCP_TRANSPORT` and `BOOKSTACK_MCP_HTTP_PORT` are read directly via
+> `Environment.GetEnvironmentVariable` in `Program.cs`; they control host construction and
+> cannot be bound through `IConfiguration` at the point they are needed.
+
+### Key Code Shapes
+
+```csharp
+// Program.cs — transport selection and host construction
+
+var transport = Environment.GetEnvironmentVariable("BOOKSTACK_MCP_TRANSPORT") ?? "stdio";
+
+if (transport is not ("stdio" or "http"))
+{
+    // Log structured error and exit before host is built
+    Console.Error.WriteLine($"Invalid BOOKSTACK_MCP_TRANSPORT value: '{transport}'. Valid values: stdio, http.");
+    return 1;
+}
+
+if (transport == "stdio")
+{
+    var host = Host.CreateDefaultBuilder(args)
+        .ConfigureLogging(logging => logging.AddConsole(o => o.LogToStandardErrorThreshold = LogLevel.Trace))
+        .ConfigureServices((ctx, services) =>
+        {
+            services.AddBookStackApiClient(ctx.Configuration);
+            services.AddMcpServer().WithStdioServerTransport().WithTools().WithResources();
+        })
+        .Build();
+
+    await host.RunAsync(cts.Token);
+}
+else
+{
+    var port = int.TryParse(Environment.GetEnvironmentVariable("BOOKSTACK_MCP_HTTP_PORT"), out var p) ? p : 3000;
+    var builder = WebApplication.CreateBuilder(args);
+    builder.Services.AddBookStackApiClient(builder.Configuration);
+    builder.Services.AddMcpServer().WithHttpTransport().WithTools().WithResources();
+    var app = builder.Build();
+    app.MapMcp();
+    await app.RunAsync($"http://0.0.0.0:{port}");
+}
+```
+
+```csharp
+// Stub tool handler — books/BookToolHandler.cs
+// Actual implementation is delivered in Issue #7
+
+[McpServerToolType]
+internal sealed class BookToolHandler(IBookStackApiClient client, ILogger<BookToolHandler> logger)
+{
+    [McpServerTool(Name = "list_books", Description = "List all books in BookStack")]
+    public Task<string> ListBooksAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #7");
+
+    [McpServerTool(Name = "get_book", Description = "Get a book by ID")]
+    public Task<string> GetBookAsync(int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #7");
+
+    // ... additional stubs
+}
+```
+
+## Acceptance Criteria
+
+- [ ] Given no `BOOKSTACK_MCP_TRANSPORT` environment variable, when `dotnet run` is executed with valid configuration, then the MCP `initialize` handshake completes over stdio within five seconds.
+- [ ] Given `BOOKSTACK_MCP_TRANSPORT=stdio`, when a `tools/list` request is sent, then the response lists descriptors for all 47+ registered stub tools without error.
+- [ ] Given `BOOKSTACK_MCP_TRANSPORT=stdio`, when a `resources/list` request is sent, then the response lists descriptors for all registered stub resources without error.
+- [ ] Given `BOOKSTACK_MCP_TRANSPORT=http` and `BOOKSTACK_MCP_HTTP_PORT=4000`, when the server starts, then it accepts MCP requests over HTTP on port 4000 and responds correctly to `initialize`.
+- [ ] Given valid configuration and `BOOKSTACK_MCP_TRANSPORT=stdio`, when SIGINT is received, then all in-flight requests complete and the process exits with code 0.
+- [ ] Given valid configuration and `BOOKSTACK_MCP_TRANSPORT=stdio`, when SIGTERM is received, then all in-flight requests complete and the process exits with code 0.
+- [ ] Given `BOOKSTACK_TOKEN_ID` is missing from configuration, when the server starts, then a structured error is logged via `ILogger` and the process exits with a non-zero exit code before the MCP handshake begins.
+- [ ] Given `BOOKSTACK_MCP_TRANSPORT=invalid`, when the server starts, then a structured error is logged and the process exits with a non-zero exit code.
+- [ ] Given the server is running, when an unhandled exception propagates to `Program.cs`, then it is logged at `Critical` level via `ILogger` and the process exits with a non-zero exit code.
+- [ ] Given `BOOKSTACK_MCP_TRANSPORT=stdio`, when the server is running, then no non-MCP content appears on stdout at any point.
+- [ ] Given a running server, when an integration test calls `tools/list`, then the response is deserializable and contains at least one tool descriptor per registered tool handler category.
+
+## Security Considerations
+
+- `BookStack:TokenId` and `BookStack:TokenSecret` MUST NOT be written to any log output at any level (OWASP A02 — Cryptographic Failures); only `BookStack:BaseUrl` may appear in startup diagnostics.
+- The Streamable HTTP endpoint MUST NOT expose diagnostic or configuration details in error responses returned to HTTP clients.
+- Environment variables are the only supported mechanism for supplying secrets; `appsettings.json` is not to be used for token values in production.
+- All tool argument validation is the responsibility of each individual tool handler (deferred to #7, #9, #16, #6, #12, #10); the server infrastructure does not need to validate tool call payloads beyond what the MCP SDK enforces.
+
+## Open Questions
+
+- None. All transport, DI, and registration decisions are covered by ADR-0001.
+
+## Out of Scope
+
+- Actual tool and resource handler implementations (deferred to #7, #9, #16, #6, #12, #10).
+- TLS / HTTPS configuration for the Streamable HTTP transport.
+- Per-request authentication for the HTTP transport endpoint.
+- Docker image or container packaging.
+- MCP prompts support.

--- a/src/BookStack.Mcp.Server/AssemblyInfo.cs
+++ b/src/BookStack.Mcp.Server/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("BookStack.Mcp.Server.Tests")]

--- a/src/BookStack.Mcp.Server/BookStack.Mcp.Server.csproj
+++ b/src/BookStack.Mcp.Server/BookStack.Mcp.Server.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,10 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
+    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/BookStack.Mcp.Server/Program.cs
+++ b/src/BookStack.Mcp.Server/Program.cs
@@ -1,4 +1,54 @@
 // BookStack MCP Server — entry point (stub)
 // Full implementation tracked in https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/14
 
-await Task.CompletedTask.ConfigureAwait(false);
+using System.Reflection;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+var transport = Environment.GetEnvironmentVariable("BOOKSTACK_MCP_TRANSPORT") ?? "stdio";
+
+if (transport is not ("stdio" or "http"))
+{
+    Console.Error.WriteLine(
+        $"Invalid BOOKSTACK_MCP_TRANSPORT value: '{transport}'. Valid values: stdio, http.");
+    return 1;
+}
+
+if (transport == "stdio")
+{
+    var builder = Host.CreateApplicationBuilder(args);
+
+    builder.Logging.AddConsole(options =>
+        options.LogToStandardErrorThreshold = LogLevel.Trace);
+
+    builder.Services.AddBookStackApiClient(builder.Configuration);
+    builder.Services
+        .AddMcpServer()
+        .WithStdioServerTransport()
+        .WithToolsFromAssembly(Assembly.GetExecutingAssembly())
+        .WithResourcesFromAssembly(Assembly.GetExecutingAssembly());
+
+    await builder.Build().RunAsync().ConfigureAwait(false);
+}
+else
+{
+    var port = int.TryParse(
+        Environment.GetEnvironmentVariable("BOOKSTACK_MCP_HTTP_PORT"), out var p) ? p : 3000;
+
+    var builder = WebApplication.CreateBuilder(args);
+    builder.Services.AddBookStackApiClient(builder.Configuration);
+    builder.Services
+        .AddMcpServer()
+        .WithHttpTransport()
+        .WithToolsFromAssembly(Assembly.GetExecutingAssembly())
+        .WithResourcesFromAssembly(Assembly.GetExecutingAssembly());
+
+    var app = builder.Build();
+    app.MapMcp();
+    await app.RunAsync($"http://0.0.0.0:{port}").ConfigureAwait(false);
+}
+
+return 0;

--- a/src/BookStack.Mcp.Server/resources/books/BookResourceHandler.cs
+++ b/src/BookStack.Mcp.Server/resources/books/BookResourceHandler.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Resources.Books;
+
+[McpServerResourceType]
+internal sealed class BookResourceHandler(
+    IBookStackApiClient client, ILogger<BookResourceHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<BookResourceHandler> _logger = logger;
+
+    [McpServerResource(UriTemplate = "bookstack://books", Name = "Books")]
+    [Description("All books in the BookStack instance")]
+    public Task<string> GetBooksAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in a future issue");
+}

--- a/src/BookStack.Mcp.Server/resources/chapters/ChapterResourceHandler.cs
+++ b/src/BookStack.Mcp.Server/resources/chapters/ChapterResourceHandler.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Resources.Chapters;
+
+[McpServerResourceType]
+internal sealed class ChapterResourceHandler(
+    IBookStackApiClient client, ILogger<ChapterResourceHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<ChapterResourceHandler> _logger = logger;
+
+    [McpServerResource(UriTemplate = "bookstack://chapters", Name = "Chapters")]
+    [Description("All chapters in the BookStack instance")]
+    public Task<string> GetChaptersAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in a future issue");
+}

--- a/src/BookStack.Mcp.Server/resources/pages/PageResourceHandler.cs
+++ b/src/BookStack.Mcp.Server/resources/pages/PageResourceHandler.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Resources.Pages;
+
+[McpServerResourceType]
+internal sealed class PageResourceHandler(
+    IBookStackApiClient client, ILogger<PageResourceHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<PageResourceHandler> _logger = logger;
+
+    [McpServerResource(UriTemplate = "bookstack://pages", Name = "Pages")]
+    [Description("All pages in the BookStack instance")]
+    public Task<string> GetPagesAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in a future issue");
+}

--- a/src/BookStack.Mcp.Server/resources/search/SearchResourceHandler.cs
+++ b/src/BookStack.Mcp.Server/resources/search/SearchResourceHandler.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Resources.Search;
+
+[McpServerResourceType]
+internal sealed class SearchResourceHandler(
+    IBookStackApiClient client, ILogger<SearchResourceHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<SearchResourceHandler> _logger = logger;
+
+    [McpServerResource(UriTemplate = "bookstack://search", Name = "Search")]
+    [Description("Search results from the BookStack instance")]
+    public Task<string> GetSearchAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in a future issue");
+}

--- a/src/BookStack.Mcp.Server/resources/shelves/ShelfResourceHandler.cs
+++ b/src/BookStack.Mcp.Server/resources/shelves/ShelfResourceHandler.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Resources.Shelves;
+
+[McpServerResourceType]
+internal sealed class ShelfResourceHandler(
+    IBookStackApiClient client, ILogger<ShelfResourceHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<ShelfResourceHandler> _logger = logger;
+
+    [McpServerResource(UriTemplate = "bookstack://shelves", Name = "Shelves")]
+    [Description("All shelves in the BookStack instance")]
+    public Task<string> GetShelvesAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in a future issue");
+}

--- a/src/BookStack.Mcp.Server/resources/users/UserResourceHandler.cs
+++ b/src/BookStack.Mcp.Server/resources/users/UserResourceHandler.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Resources.Users;
+
+[McpServerResourceType]
+internal sealed class UserResourceHandler(
+    IBookStackApiClient client, ILogger<UserResourceHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<UserResourceHandler> _logger = logger;
+
+    [McpServerResource(UriTemplate = "bookstack://users", Name = "Users")]
+    [Description("All users in the BookStack instance")]
+    public Task<string> GetUsersAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in a future issue");
+}

--- a/src/BookStack.Mcp.Server/tools/attachments/AttachmentToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/attachments/AttachmentToolHandler.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Tools.Attachments;
+
+[McpServerToolType]
+internal sealed class AttachmentToolHandler(IBookStackApiClient client, ILogger<AttachmentToolHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<AttachmentToolHandler> _logger = logger;
+
+    [McpServerTool(Name = "bookstack_attachments_list"), Description("List all attachments in BookStack")]
+    public Task<string> ListAttachmentsAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #6");
+
+    [McpServerTool(Name = "bookstack_attachments_read"), Description("Get an attachment by ID")]
+    public Task<string> ReadAttachmentAsync(
+        [Description("The attachment ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #6");
+
+    [McpServerTool(Name = "bookstack_attachments_create"), Description("Create a new attachment")]
+    public Task<string> CreateAttachmentAsync(
+        [Description("The attachment name")] string name, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #6");
+
+    [McpServerTool(Name = "bookstack_attachments_update"), Description("Update an existing attachment")]
+    public Task<string> UpdateAttachmentAsync(
+        [Description("The attachment ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #6");
+
+    [McpServerTool(Name = "bookstack_attachments_delete"), Description("Delete an attachment by ID")]
+    public Task<string> DeleteAttachmentAsync(
+        [Description("The attachment ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #6");
+}

--- a/src/BookStack.Mcp.Server/tools/audit/AuditToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/audit/AuditToolHandler.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Tools.Audit;
+
+[McpServerToolType]
+internal sealed class AuditToolHandler(IBookStackApiClient client, ILogger<AuditToolHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<AuditToolHandler> _logger = logger;
+
+    [McpServerTool(Name = "bookstack_audit_log_list"), Description("List audit log entries from BookStack")]
+    public Task<string> ListAuditLogAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #10");
+}

--- a/src/BookStack.Mcp.Server/tools/books/BookToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/books/BookToolHandler.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Tools.Books;
+
+[McpServerToolType]
+internal sealed class BookToolHandler(IBookStackApiClient client, ILogger<BookToolHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<BookToolHandler> _logger = logger;
+
+    [McpServerTool(Name = "bookstack_books_list"), Description("List all books in BookStack")]
+    public Task<string> ListBooksAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #7");
+
+    [McpServerTool(Name = "bookstack_books_read"), Description("Get a book by ID")]
+    public Task<string> ReadBookAsync(
+        [Description("The book ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #7");
+
+    [McpServerTool(Name = "bookstack_books_create"), Description("Create a new book")]
+    public Task<string> CreateBookAsync(
+        [Description("The book name")] string name, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #7");
+
+    [McpServerTool(Name = "bookstack_books_update"), Description("Update an existing book")]
+    public Task<string> UpdateBookAsync(
+        [Description("The book ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #7");
+
+    [McpServerTool(Name = "bookstack_books_delete"), Description("Delete a book by ID")]
+    public Task<string> DeleteBookAsync(
+        [Description("The book ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #7");
+
+    [McpServerTool(Name = "bookstack_books_export"), Description("Export a book in a given format")]
+    public Task<string> ExportBookAsync(
+        [Description("The book ID")] int id,
+        [Description("Export format: html, pdf, plaintext, markdown")] string format,
+        CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #7");
+}

--- a/src/BookStack.Mcp.Server/tools/chapters/ChapterToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/chapters/ChapterToolHandler.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Tools.Chapters;
+
+[McpServerToolType]
+internal sealed class ChapterToolHandler(IBookStackApiClient client, ILogger<ChapterToolHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<ChapterToolHandler> _logger = logger;
+
+    [McpServerTool(Name = "bookstack_chapters_list"), Description("List all chapters in BookStack")]
+    public Task<string> ListChaptersAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+
+    [McpServerTool(Name = "bookstack_chapters_read"), Description("Get a chapter by ID")]
+    public Task<string> ReadChapterAsync(
+        [Description("The chapter ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+
+    [McpServerTool(Name = "bookstack_chapters_create"), Description("Create a new chapter")]
+    public Task<string> CreateChapterAsync(
+        [Description("The chapter name")] string name, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+
+    [McpServerTool(Name = "bookstack_chapters_update"), Description("Update an existing chapter")]
+    public Task<string> UpdateChapterAsync(
+        [Description("The chapter ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+
+    [McpServerTool(Name = "bookstack_chapters_delete"), Description("Delete a chapter by ID")]
+    public Task<string> DeleteChapterAsync(
+        [Description("The chapter ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+
+    [McpServerTool(Name = "bookstack_chapters_export"), Description("Export a chapter in a given format")]
+    public Task<string> ExportChapterAsync(
+        [Description("The chapter ID")] int id,
+        [Description("Export format: html, pdf, plaintext, markdown")] string format,
+        CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+}

--- a/src/BookStack.Mcp.Server/tools/images/ImageToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/images/ImageToolHandler.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Tools.Images;
+
+[McpServerToolType]
+internal sealed class ImageToolHandler(IBookStackApiClient client, ILogger<ImageToolHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<ImageToolHandler> _logger = logger;
+
+    [McpServerTool(Name = "bookstack_images_list"), Description("List all images in BookStack")]
+    public Task<string> ListImagesAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #6");
+
+    [McpServerTool(Name = "bookstack_images_read"), Description("Get an image by ID")]
+    public Task<string> ReadImageAsync(
+        [Description("The image ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #6");
+
+    [McpServerTool(Name = "bookstack_images_create"), Description("Create a new image")]
+    public Task<string> CreateImageAsync(
+        [Description("The image name")] string name, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #6");
+
+    [McpServerTool(Name = "bookstack_images_update"), Description("Update an existing image")]
+    public Task<string> UpdateImageAsync(
+        [Description("The image ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #6");
+
+    [McpServerTool(Name = "bookstack_images_delete"), Description("Delete an image by ID")]
+    public Task<string> DeleteImageAsync(
+        [Description("The image ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #6");
+}

--- a/src/BookStack.Mcp.Server/tools/pages/PageToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/pages/PageToolHandler.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Tools.Pages;
+
+[McpServerToolType]
+internal sealed class PageToolHandler(IBookStackApiClient client, ILogger<PageToolHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<PageToolHandler> _logger = logger;
+
+    [McpServerTool(Name = "bookstack_pages_list"), Description("List all pages in BookStack")]
+    public Task<string> ListPagesAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+
+    [McpServerTool(Name = "bookstack_pages_read"), Description("Get a page by ID")]
+    public Task<string> ReadPageAsync(
+        [Description("The page ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+
+    [McpServerTool(Name = "bookstack_pages_create"), Description("Create a new page")]
+    public Task<string> CreatePageAsync(
+        [Description("The page name")] string name, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+
+    [McpServerTool(Name = "bookstack_pages_update"), Description("Update an existing page")]
+    public Task<string> UpdatePageAsync(
+        [Description("The page ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+
+    [McpServerTool(Name = "bookstack_pages_delete"), Description("Delete a page by ID")]
+    public Task<string> DeletePageAsync(
+        [Description("The page ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+
+    [McpServerTool(Name = "bookstack_pages_export"), Description("Export a page in a given format")]
+    public Task<string> ExportPageAsync(
+        [Description("The page ID")] int id,
+        [Description("Export format: html, pdf, plaintext, markdown")] string format,
+        CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+}

--- a/src/BookStack.Mcp.Server/tools/permissions/PermissionToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/permissions/PermissionToolHandler.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Tools.Permissions;
+
+[McpServerToolType]
+internal sealed class PermissionToolHandler(IBookStackApiClient client, ILogger<PermissionToolHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<PermissionToolHandler> _logger = logger;
+
+    [McpServerTool(Name = "bookstack_permissions_read"), Description("Read content permissions for an item")]
+    public Task<string> ReadPermissionsAsync(
+        [Description("The content type (book, chapter, page, bookshelf)")] string contentType,
+        [Description("The content item ID")] int id,
+        CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #10");
+
+    [McpServerTool(Name = "bookstack_permissions_update"), Description("Update content permissions for an item")]
+    public Task<string> UpdatePermissionsAsync(
+        [Description("The content type (book, chapter, page, bookshelf)")] string contentType,
+        [Description("The content item ID")] int id,
+        CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #10");
+}

--- a/src/BookStack.Mcp.Server/tools/recyclebin/RecycleBinToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/recyclebin/RecycleBinToolHandler.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Tools.RecycleBin;
+
+[McpServerToolType]
+internal sealed class RecycleBinToolHandler(IBookStackApiClient client, ILogger<RecycleBinToolHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<RecycleBinToolHandler> _logger = logger;
+
+    [McpServerTool(Name = "bookstack_recyclebin_list"), Description("List all items in the BookStack recycle bin")]
+    public Task<string> ListRecycleBinAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #10");
+
+    [McpServerTool(Name = "bookstack_recyclebin_restore"), Description("Restore an item from the recycle bin")]
+    public Task<string> RestoreRecycleBinAsync(
+        [Description("The recycle bin item ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #10");
+
+    [McpServerTool(Name = "bookstack_recyclebin_delete_permanently"), Description("Permanently delete an item from the recycle bin")]
+    public Task<string> DeletePermanentlyAsync(
+        [Description("The recycle bin item ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #10");
+}

--- a/src/BookStack.Mcp.Server/tools/roles/RoleToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/roles/RoleToolHandler.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Tools.Roles;
+
+[McpServerToolType]
+internal sealed class RoleToolHandler(IBookStackApiClient client, ILogger<RoleToolHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<RoleToolHandler> _logger = logger;
+
+    [McpServerTool(Name = "bookstack_roles_list"), Description("List all roles in BookStack")]
+    public Task<string> ListRolesAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #16");
+
+    [McpServerTool(Name = "bookstack_roles_read"), Description("Get a role by ID")]
+    public Task<string> ReadRoleAsync(
+        [Description("The role ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #16");
+
+    [McpServerTool(Name = "bookstack_roles_create"), Description("Create a new role")]
+    public Task<string> CreateRoleAsync(
+        [Description("The role display name")] string name, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #16");
+
+    [McpServerTool(Name = "bookstack_roles_update"), Description("Update an existing role")]
+    public Task<string> UpdateRoleAsync(
+        [Description("The role ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #16");
+
+    [McpServerTool(Name = "bookstack_roles_delete"), Description("Delete a role by ID")]
+    public Task<string> DeleteRoleAsync(
+        [Description("The role ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #16");
+}

--- a/src/BookStack.Mcp.Server/tools/search/SearchToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/search/SearchToolHandler.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Tools.Search;
+
+[McpServerToolType]
+internal sealed class SearchToolHandler(IBookStackApiClient client, ILogger<SearchToolHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<SearchToolHandler> _logger = logger;
+
+    [McpServerTool(Name = "bookstack_search"), Description("Search for content across BookStack")]
+    public Task<string> SearchAsync(
+        [Description("The search query")] string query, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #12");
+}

--- a/src/BookStack.Mcp.Server/tools/server-info/ServerInfoToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/server-info/ServerInfoToolHandler.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Tools.ServerInfo;
+
+[McpServerToolType]
+internal sealed class ServerInfoToolHandler(IBookStackApiClient client, ILogger<ServerInfoToolHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<ServerInfoToolHandler> _logger = logger;
+
+    [McpServerTool(Name = "bookstack_server_info"), Description("Get information about the BookStack MCP server")]
+    public Task<string> GetServerInfoAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #10");
+
+    [McpServerTool(Name = "bookstack_help"), Description("Get help and usage information for available tools")]
+    public Task<string> GetHelpAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #10");
+
+    [McpServerTool(Name = "bookstack_error_guides"), Description("Get error guides and troubleshooting information")]
+    public Task<string> GetErrorGuidesAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #10");
+
+    [McpServerTool(Name = "bookstack_tool_categories"), Description("Get a categorized list of available tools")]
+    public Task<string> GetToolCategoriesAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #10");
+
+    [McpServerTool(Name = "bookstack_usage_examples"), Description("Get usage examples for common workflows")]
+    public Task<string> GetUsageExamplesAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #10");
+}

--- a/src/BookStack.Mcp.Server/tools/shelves/ShelfToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/shelves/ShelfToolHandler.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Tools.Shelves;
+
+[McpServerToolType]
+internal sealed class ShelfToolHandler(IBookStackApiClient client, ILogger<ShelfToolHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<ShelfToolHandler> _logger = logger;
+
+    [McpServerTool(Name = "bookstack_shelves_list"), Description("List all shelves in BookStack")]
+    public Task<string> ListShelvesAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+
+    [McpServerTool(Name = "bookstack_shelves_read"), Description("Get a shelf by ID")]
+    public Task<string> ReadShelfAsync(
+        [Description("The shelf ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+
+    [McpServerTool(Name = "bookstack_shelves_create"), Description("Create a new shelf")]
+    public Task<string> CreateShelfAsync(
+        [Description("The shelf name")] string name, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+
+    [McpServerTool(Name = "bookstack_shelves_update"), Description("Update an existing shelf")]
+    public Task<string> UpdateShelfAsync(
+        [Description("The shelf ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+
+    [McpServerTool(Name = "bookstack_shelves_delete"), Description("Delete a shelf by ID")]
+    public Task<string> DeleteShelfAsync(
+        [Description("The shelf ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #9");
+}

--- a/src/BookStack.Mcp.Server/tools/system/SystemToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/system/SystemToolHandler.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Tools.System;
+
+[McpServerToolType]
+internal sealed class SystemToolHandler(IBookStackApiClient client, ILogger<SystemToolHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<SystemToolHandler> _logger = logger;
+
+    [McpServerTool(Name = "bookstack_system_info"), Description("Get system information from the BookStack instance")]
+    public Task<string> GetSystemInfoAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #10");
+}

--- a/src/BookStack.Mcp.Server/tools/users/UserToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/users/UserToolHandler.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel;
+using BookStack.Mcp.Server.Api;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Tools.Users;
+
+[McpServerToolType]
+internal sealed class UserToolHandler(IBookStackApiClient client, ILogger<UserToolHandler> logger)
+{
+    private readonly IBookStackApiClient _client = client;
+    private readonly ILogger<UserToolHandler> _logger = logger;
+
+    [McpServerTool(Name = "bookstack_users_list"), Description("List all users in BookStack")]
+    public Task<string> ListUsersAsync(CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #16");
+
+    [McpServerTool(Name = "bookstack_users_read"), Description("Get a user by ID")]
+    public Task<string> ReadUserAsync(
+        [Description("The user ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #16");
+
+    [McpServerTool(Name = "bookstack_users_create"), Description("Create a new user")]
+    public Task<string> CreateUserAsync(
+        [Description("The user display name")] string name, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #16");
+
+    [McpServerTool(Name = "bookstack_users_update"), Description("Update an existing user")]
+    public Task<string> UpdateUserAsync(
+        [Description("The user ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #16");
+
+    [McpServerTool(Name = "bookstack_users_delete"), Description("Delete a user by ID")]
+    public Task<string> DeleteUserAsync(
+        [Description("The user ID")] int id, CancellationToken ct)
+        => throw new NotImplementedException("Implemented in Issue #16");
+}

--- a/tests/BookStack.Mcp.Server.Tests/server/McpHandlerAttributeTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/server/McpHandlerAttributeTests.cs
@@ -1,0 +1,70 @@
+using System.Reflection;
+using BookStack.Mcp.Server.Tools.Books;
+using ModelContextProtocol.Server;
+using TUnit.Core;
+
+namespace BookStack.Mcp.Server.Tests.Server;
+
+public sealed class McpHandlerAttributeTests
+{
+    [Test]
+    public async Task BookToolHandler_IsDecoratedWithMcpServerToolTypeAttribute()
+    {
+        var hasAttr = typeof(BookToolHandler)
+            .GetCustomAttribute<McpServerToolTypeAttribute>() is not null;
+
+        var result = hasAttr;
+        await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task ServerAssembly_ContainsAtLeastFourteenToolHandlerTypes()
+    {
+        var assembly = typeof(BookToolHandler).Assembly;
+        var toolTypes = assembly.GetTypes()
+            .Where(t => t.GetCustomAttribute<McpServerToolTypeAttribute>() is not null)
+            .ToList();
+
+        var count = toolTypes.Count;
+        await Assert.That(count).IsGreaterThanOrEqualTo(14);
+    }
+
+    [Test]
+    public async Task ServerAssembly_ContainsAtLeastSixResourceHandlerTypes()
+    {
+        var assembly = typeof(BookToolHandler).Assembly;
+        var resourceTypes = assembly.GetTypes()
+            .Where(t => t.GetCustomAttribute<McpServerResourceTypeAttribute>() is not null)
+            .ToList();
+
+        var count = resourceTypes.Count;
+        await Assert.That(count).IsGreaterThanOrEqualTo(6);
+    }
+
+    [Test]
+    public async Task AllToolMethods_HaveMcpServerToolAttributeWithNonEmptyName()
+    {
+        var assembly = typeof(BookToolHandler).Assembly;
+        var toolHandlerTypes = assembly.GetTypes()
+            .Where(t => t.GetCustomAttribute<McpServerToolTypeAttribute>() is not null);
+
+        foreach (var type in toolHandlerTypes)
+        {
+            var toolMethods = type.GetMethods(
+                    BindingFlags.Instance | BindingFlags.Static |
+                    BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(m => m.GetCustomAttribute<McpServerToolAttribute>() is not null)
+                .ToList();
+
+            var hasToolMethods = toolMethods.Count > 0;
+            await Assert.That(hasToolMethods).IsTrue();
+
+            foreach (var method in toolMethods)
+            {
+                var attr = method.GetCustomAttribute<McpServerToolAttribute>()!;
+                var hasName = !string.IsNullOrWhiteSpace(attr.Name);
+                await Assert.That(hasName).IsTrue();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements [#8 — MCP server infrastructure](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/8) following [ADR-0009](docs/architecture/decisions/ADR-0009-dual-transport-entry-point.md).

## Changes

### `#40` — Project SDK + NuGet packages
- Changed `BookStack.Mcp.Server.csproj` from `Microsoft.NET.Sdk` → `Microsoft.NET.Sdk.Web`
- Added `ModelContextProtocol 1.2.0` and `ModelContextProtocol.AspNetCore 1.2.0`
- Removed redundant `Microsoft.Extensions.*` refs (now provided transitively by the Web SDK)

### `#37` — `Program.cs` — Dual-transport entry point
- Reads `BOOKSTACK_MCP_TRANSPORT` env var (`stdio` [default] | `http`)
- Rejects invalid values with an error message to `stderr` and exit code `1`
- **stdio branch**: `Host.CreateApplicationBuilder` + `WithStdioServerTransport()` + all logs routed to stderr
- **HTTP branch**: `WebApplication.CreateBuilder` + `WithHttpTransport()` + `app.MapMcp()`, port via `BOOKSTACK_MCP_HTTP_PORT` (default `3000`)
- Both branches wire `AddBookStackApiClient` and use `WithToolsFromAssembly` / `WithResourcesFromAssembly`

### `#38` — 14 stub tool handler classes
Under `src/BookStack.Mcp.Server/tools/`:
`books/`, `chapters/`, `pages/`, `shelves/`, `users/`, `roles/`, `attachments/`, `images/`, `search/`, `recyclebin/`, `permissions/`, `audit/`, `system/`, `server-info/`

Each class is `[McpServerToolType]`, `internal sealed`, injects `IBookStackApiClient` + `ILogger<T>`, and has stub methods throwing `NotImplementedException`.

### `#39` — 6 stub resource handler classes
Under `src/BookStack.Mcp.Server/resources/`:
`books/`, `chapters/`, `pages/`, `shelves/`, `users/`, `search/`

Each class is `[McpServerResourceType]`, `internal sealed`, with stub `[McpServerResource]` methods.

### `#41` — Tests
- `tests/.../server/McpHandlerAttributeTests.cs` — 4 tests verifying attribute decoration and assembly scan counts (≥14 tools, ≥6 resources)
- `AssemblyInfo.cs` with `InternalsVisibleTo("BookStack.Mcp.Server.Tests")`

## Test Results

```
total: 41 | failed: 0 | succeeded: 41 | skipped: 0
```

Closes #8 #37 #38 #39 #40 #41