### PR TITLE
feat(#7): CRUD tools and resources for books, chapters, pages, and shelves

### DIFF
--- a/docs/architecture/decisions/ADR-0010-tool-handler-output-json-policy.md
+++ b/docs/architecture/decisions/ADR-0010-tool-handler-output-json-policy.md
@@ -1,0 +1,109 @@
+# ADR-0010: Tool and Resource Handler JSON Output Naming Policy
+
+**Status**: Accepted
+**Date**: 2026-04-20
+**Author**: GitHub Copilot
+**Deciders**: bookstack-mcp-server-dotnet maintainers
+
+---
+
+## Context
+
+MCP tool and resource handlers serialize their results as JSON strings that are returned to MCP
+clients (LLM agents, Claude Desktop, etc.). The C# models use PascalCase properties
+(`BookId`, `CreatedAt`), while BookStack's own REST API returns snake_case JSON (`book_id`,
+`created_at`). When re-serializing deserialized models for MCP output, a naming policy must be
+selected.
+
+ADR-0006 already established `JsonNamingPolicy.SnakeCaseLower` for the `BookStackApiClient`'s
+deserialization of BookStack HTTP responses. This ADR governs the **output** side: what naming
+policy tool and resource handler methods use when serializing results back to MCP clients.
+
+The naming policy must be consistent across all 23 tools and 8 resources in FEAT-0007 and all
+future handler implementations.
+
+## Decision
+
+We will use **`JsonNamingPolicy.CamelCase`** for all tool and resource handler JSON output.
+
+Each handler class declares a `private static readonly JsonSerializerOptions _jsonOptions`
+field that is shared across all methods of that handler. No cross-handler singleton is introduced;
+the field is local to each class.
+
+```csharp
+private static readonly JsonSerializerOptions _jsonOptions = new()
+{
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    WriteIndented = false,
+};
+```
+
+This field is the **only** serializer options instance used for output within a given handler
+class. The API client's `JsonOptions` (SnakeCaseLower) are not exposed or reused in handler code.
+
+## Rationale
+
+The MCP protocol originated in the JavaScript/TypeScript ecosystem, and most MCP clients — including
+Claude Desktop and the TypeScript MCP SDK — use camelCase JSON as the convention for tool
+argument objects and results. Using camelCase output aligns with the expectations of the clients
+that consume this server's tools.
+
+`SnakeCaseLower` would produce output that mirrors BookStack's API format, which could be useful
+for callers who already know the BookStack schema. However, it couples the MCP output format to
+BookStack's implementation detail rather than the MCP ecosystem convention. If BookStack changes
+a field name, callers would need to update their consumption logic regardless of the naming policy.
+
+A shared cross-handler singleton was considered but rejected (see Alternatives) to avoid an
+artificial shared-state dependency between otherwise stateless handler classes.
+
+## Alternatives Considered
+
+### Option A: `JsonNamingPolicy.SnakeCaseLower` (mirror BookStack format)
+
+- **Pros**: Output format matches BookStack API documentation exactly; no mismatch for callers
+  familiar with BookStack REST API field names (`book_id`, `created_at`, etc.).
+- **Cons**: Diverges from the MCP/JSON-API camelCase convention; couples MCP output to BookStack
+  naming conventions; inconsistent with the direction of most MCP implementations.
+- **Why rejected**: CamelCase is more appropriate for the MCP ecosystem and is the convention used
+  by the TypeScript reference implementation when it re-serializes API responses.
+
+### Option B: Shared static singleton in a utility class
+
+- **Pros**: Single instance allocation; avoids per-class field declarations.
+- **Cons**: Introduces a shared-state dependency between otherwise stateless handler classes;
+  any change to the shared options affects all handlers simultaneously; harder to override for
+  a specific handler if needed in the future.
+- **Why rejected**: The allocation cost of a `static readonly` field is negligible (one instance
+  per class, created once at first use). Keeping the field local to each handler class preserves
+  handler independence.
+
+### Option C: Per-handler options with varying policies
+
+- **Pros**: Maximum flexibility.
+- **Cons**: Inconsistent output format across tools; breaks MCP client expectations.
+- **Why rejected**: Consistency is more valuable than flexibility here; all tools must produce
+  uniform output.
+
+## Consequences
+
+### Positive
+
+- All 23 tools and 8 resources produce camelCase JSON output, consistent with MCP ecosystem
+  conventions.
+- Each handler class is self-contained; no dependency on a shared serialization utility.
+- `WriteIndented = false` keeps response payloads compact.
+- The policy is explicit and documented, preventing future contributors from accidentally using
+  the API client's SnakeCaseLower options for handler output.
+
+### Negative / Trade-offs
+
+- Output field names (`bookId`, `createdAt`) differ from BookStack's own API field names
+  (`book_id`, `created_at`). MCP clients that parse tool results expecting BookStack field names
+  will need to use the camelCase variants.
+- Each handler class repeats the `_jsonOptions` field declaration. This is intentional (see
+  rejected Option B) but adds a small amount of boilerplate per class.
+
+## Related ADRs
+
+- [ADR-0006: System.Text.Json with SnakeCaseLower Naming Policy](ADR-0006-systemtextjson-snakecase.md)
+- [ADR-0008: Typed Exception for HTTP Errors (BookStackApiException)](ADR-0008-bookstackapiexception.md)

--- a/docs/features/content-tools-resources/spec.md
+++ b/docs/features/content-tools-resources/spec.md
@@ -1,0 +1,289 @@
+# Feature Spec: Content Tools & Resources — Books, Chapters, Pages, Shelves
+
+**ID**: FEAT-0007
+**Status**: Draft
+**Author**: Mark Burton
+**Created**: 2026-04-20
+**Last Updated**: 2026-04-20
+**GitHub Issue**: [#7](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/7)
+**Related ADRs**:
+- [ADR-0001](../architecture/decisions/ADR-0001-mcp-sdk-selection.md) — MCP SDK Selection
+- [ADR-0002](../architecture/decisions/ADR-0002-solution-structure.md) — Solution and Project Structure
+- [ADR-0005](../architecture/decisions/ADR-0005-ihttpclientfactory-typed-client.md) — IHttpClientFactory Typed Client
+- [ADR-0006](../architecture/decisions/ADR-0006-systemtextjson-snakecase.md) — System.Text.Json snake_case serialisation
+- [ADR-0008](../architecture/decisions/ADR-0008-bookstackapiexception.md) — BookStackApiException
+
+---
+
+## Problem Statement
+
+The MCP server infrastructure (FEAT-0008) established the dual-transport entry point and
+registered 14 stub tool handlers and 6 stub resource handlers via assembly scan. All stub methods
+currently throw `NotImplementedException`. This means no MCP client can yet perform any meaningful
+operation against a BookStack instance. The content domain — books, chapters, pages, and shelves —
+represents the majority of day-to-day MCP usage and must be fully implemented first.
+
+---
+
+## Goals
+
+1. Replace the `NotImplementedException` stubs in `BookToolHandler`, `ChapterToolHandler`,
+   `PageToolHandler`, and `ShelfToolHandler` with real implementations that call
+   `IBookStackApiClient`.
+2. Replace the stubs in `BookResourceHandler`, `ChapterResourceHandler`, `PageResourceHandler`, and
+   `ShelfResourceHandler` with real implementations.
+3. Validate all MCP tool inputs at the handler boundary before forwarding to the API client.
+4. Return structured JSON strings that MCP clients can parse and display.
+5. Propagate `BookStackApiException` as a meaningful MCP error rather than an unhandled exception.
+
+---
+
+## Non-Goals
+
+- Implementing users, roles, attachments, images, search, recycle bin, permissions, or audit log
+  (covered by separate issues #9, #6, #12, #10).
+- Pagination UI or cursor-based pagination beyond what the BookStack API supports.
+- Real-time streaming or WebSocket push of content changes.
+- Full-text content indexing or local caching.
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+#### Books
+
+1. `bookstack_books_list` MUST accept optional `count` (int, 1–500, default 20), `offset` (int,
+   ≥0, default 0), and `sort` (`name` | `created_at` | `updated_at`, default `name`) parameters
+   and return a JSON-serialised `ListResponse<Book>`.
+2. `bookstack_books_create` MUST accept required `name` (string, max 255 chars) and optional
+   `description` (string, max 1900 chars), `description_html` (string, max 2000 chars), `tags`
+   (array of `{name, value}` objects), `image_id` (int), and `default_template_id` (int). It MUST
+   return the created `Book` as JSON.
+3. `bookstack_books_read` MUST accept required `id` (int, >0) and return the `BookWithContents`
+   (including nested chapters and pages) as JSON.
+4. `bookstack_books_update` MUST accept required `id` (int, >0) and any subset of the fields
+   listed for create (all optional on update). It MUST return the updated `Book` as JSON.
+5. `bookstack_books_delete` MUST accept required `id` (int, >0) and return a confirmation message
+   on success.
+6. `bookstack_books_export` MUST accept required `id` (int, >0) and required `format`
+   (`html` | `pdf` | `plaintext` | `markdown`) and return the export content as a string.
+
+#### Chapters
+
+7. `bookstack_chapters_list` MUST accept the same pagination/sort parameters as books list and
+   return `ListResponse<Chapter>` as JSON.
+8. `bookstack_chapters_create` MUST accept required `book_id` (int, >0) and `name` (string, max
+   255 chars), plus optional `description`, `description_html`, and `tags`. It MUST return the
+   created `Chapter` as JSON.
+9. `bookstack_chapters_read` MUST accept required `id` (int, >0) and return `ChapterWithPages`
+   (including nested pages) as JSON.
+10. `bookstack_chapters_update` MUST accept required `id` (int, >0) and any subset of the
+    writeable chapter fields. It MUST return the updated `Chapter` as JSON.
+11. `bookstack_chapters_delete` MUST accept required `id` (int, >0) and return a confirmation
+    message on success.
+12. `bookstack_chapters_export` MUST accept required `id` (int, >0) and required `format`
+    (`html` | `pdf` | `plaintext` | `markdown`) and return the export content as a string.
+
+#### Pages
+
+13. `bookstack_pages_list` MUST accept the same pagination/sort parameters and return
+    `ListResponse<Page>` as JSON.
+14. `bookstack_pages_create` MUST accept optional `book_id` (int, >0) OR `chapter_id` (int, >0)
+    (at least one MUST be provided), required `name` (string, max 255 chars), and optional `html`
+    (string), `markdown` (string), and `tags`. Only one of `html` or `markdown` SHOULD be
+    provided; `html` takes precedence if both are given. It MUST return the created `Page` as JSON.
+15. `bookstack_pages_read` MUST accept required `id` (int, >0) and return `PageWithContent`
+    (including `html` and `markdown` body fields) as JSON.
+16. `bookstack_pages_update` MUST accept required `id` (int, >0) and any subset of the writeable
+    page fields. It MUST return the updated `Page` as JSON.
+17. `bookstack_pages_delete` MUST accept required `id` (int, >0) and return a confirmation message
+    on success.
+18. `bookstack_pages_export` MUST accept required `id` (int, >0) and required `format`
+    (`html` | `pdf` | `plaintext` | `markdown`) and return the export content as a string.
+
+#### Shelves
+
+19. `bookstack_shelves_list` MUST accept the same pagination/sort parameters and return
+    `ListResponse<Bookshelf>` as JSON.
+20. `bookstack_shelves_create` MUST accept required `name` (string, max 255 chars), optional
+    `description`, `description_html`, `tags`, and `books` (array of int book IDs). It MUST return
+    the created `Bookshelf` as JSON.
+21. `bookstack_shelves_read` MUST accept required `id` (int, >0) and return `BookshelfWithBooks`
+    (including nested book list) as JSON.
+22. `bookstack_shelves_update` MUST accept required `id` (int, >0) and any subset of the writeable
+    shelf fields. It MUST return the updated `Bookshelf` as JSON.
+23. `bookstack_shelves_delete` MUST accept required `id` (int, >0) and return a confirmation
+    message on success.
+
+#### Resources
+
+24. `bookstack://books` resource MUST return a JSON-serialised `ListResponse<Book>` for the first
+    page (count=20).
+25. `bookstack://chapters` resource MUST return a JSON-serialised `ListResponse<Chapter>` for the
+    first page.
+26. `bookstack://pages` resource MUST return a JSON-serialised `ListResponse<Page>` for the first
+    page.
+27. `bookstack://shelves` resource MUST return a JSON-serialised `ListResponse<Bookshelf>` for the
+    first page.
+
+#### Error Handling
+
+28. When `IBookStackApiClient` throws a `BookStackApiException` with HTTP 404, the tool MUST
+    return an MCP error response with message `"Not found: {entity} {id}"` rather than propagating
+    the exception unhandled.
+29. When required parameters are missing or invalid (e.g., `id ≤ 0`, `name` empty or too long),
+    the tool MUST return an MCP error response with a descriptive validation message before making
+    any API call.
+30. When `IBookStackApiClient` throws a `BookStackApiException` with HTTP 429 (rate-limit), the
+    tool MUST surface the error as an MCP error response with a `"Rate limit exceeded"` message.
+
+### Non-Functional Requirements
+
+1. Each tool implementation MUST NOT make more than one HTTP call to BookStack per tool invocation.
+2. Serialised JSON responses MUST use snake_case field names (per ADR-0006).
+3. Tool handlers MUST use `ILogger<T>` at `Debug` level for successful operations and `Warning`
+   level for validation errors; `Console.WriteLine` MUST NOT be used.
+4. All handler methods MUST be `async Task<string>` and `await` all async calls with
+   `.ConfigureAwait(false)`.
+
+---
+
+## Design
+
+### Component Diagram
+
+```mermaid
+graph TD
+    Client[MCP Client]
+    Tools[Tool Handlers<br/>books / chapters / pages / shelves]
+    Resources[Resource Handlers<br/>books / chapters / pages / shelves]
+    ApiClient[IBookStackApiClient]
+    BookStack[BookStack API v25]
+
+    Client -->|MCP tool call| Tools
+    Client -->|MCP resource read| Resources
+    Tools -->|CRUD + export| ApiClient
+    Resources -->|list first page| ApiClient
+    ApiClient -->|HTTP + token auth| BookStack
+```
+
+### Tool Interface
+
+#### Books
+
+| Tool | Required params | Optional params | Return type |
+|---|---|---|---|
+| `bookstack_books_list` | — | `count`, `offset`, `sort` | `ListResponse<Book>` JSON |
+| `bookstack_books_create` | `name` | `description`, `description_html`, `tags`, `image_id`, `default_template_id` | `Book` JSON |
+| `bookstack_books_read` | `id` | — | `BookWithContents` JSON |
+| `bookstack_books_update` | `id` | `name`, `description`, `description_html`, `tags`, `image_id`, `default_template_id` | `Book` JSON |
+| `bookstack_books_delete` | `id` | — | confirmation string |
+| `bookstack_books_export` | `id`, `format` | — | export content string |
+
+#### Chapters
+
+| Tool | Required params | Optional params | Return type |
+|---|---|---|---|
+| `bookstack_chapters_list` | — | `count`, `offset`, `sort` | `ListResponse<Chapter>` JSON |
+| `bookstack_chapters_create` | `book_id`, `name` | `description`, `description_html`, `tags` | `Chapter` JSON |
+| `bookstack_chapters_read` | `id` | — | `ChapterWithPages` JSON |
+| `bookstack_chapters_update` | `id` | `book_id`, `name`, `description`, `description_html`, `tags` | `Chapter` JSON |
+| `bookstack_chapters_delete` | `id` | — | confirmation string |
+| `bookstack_chapters_export` | `id`, `format` | — | export content string |
+
+#### Pages
+
+| Tool | Required params | Optional params | Return type |
+|---|---|---|---|
+| `bookstack_pages_list` | — | `count`, `offset`, `sort` | `ListResponse<Page>` JSON |
+| `bookstack_pages_create` | `name`, (`book_id` OR `chapter_id`) | `html`, `markdown`, `tags` | `Page` JSON |
+| `bookstack_pages_read` | `id` | — | `PageWithContent` JSON |
+| `bookstack_pages_update` | `id` | `book_id`, `chapter_id`, `name`, `html`, `markdown`, `tags` | `Page` JSON |
+| `bookstack_pages_delete` | `id` | — | confirmation string |
+| `bookstack_pages_export` | `id`, `format` | — | export content string |
+
+#### Shelves
+
+| Tool | Required params | Optional params | Return type |
+|---|---|---|---|
+| `bookstack_shelves_list` | — | `count`, `offset`, `sort` | `ListResponse<Bookshelf>` JSON |
+| `bookstack_shelves_create` | `name` | `description`, `description_html`, `tags`, `books` | `Bookshelf` JSON |
+| `bookstack_shelves_read` | `id` | — | `BookshelfWithBooks` JSON |
+| `bookstack_shelves_update` | `id` | `name`, `description`, `description_html`, `tags`, `books` | `Bookshelf` JSON |
+| `bookstack_shelves_delete` | `id` | — | confirmation string |
+
+### Implementation Pattern
+
+All tool handlers follow a uniform pattern:
+
+```csharp
+[McpServerTool(Name = "bookstack_books_list"), Description("...")]
+public async Task<string> ListBooksAsync(
+    [Description("Number of books to return (1–500)")] int count = 20,
+    [Description("Number of books to skip")] int offset = 0,
+    [Description("Sort field: name, created_at, updated_at")] string sort = "name",
+    CancellationToken ct = default)
+{
+    _logger.LogDebug("Listing books count={Count} offset={Offset}", count, offset);
+    var result = await _client.ListBooksAsync(
+        new ListQueryParams { Count = count, Offset = offset, Sort = sort },
+        ct).ConfigureAwait(false);
+    return JsonSerializer.Serialize(result, JsonOptions.Default);
+}
+```
+
+Error handling is centralised in a private helper that catches `BookStackApiException` and converts
+it to a descriptive string error response.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Given a BookStack instance with 3 books, when `bookstack_books_list` is called with no
+  arguments, then the response is valid JSON containing a `data` array of 3 book objects.
+- [ ] Given a valid book `name`, when `bookstack_books_create` is called, then a `Book` JSON object
+  with a non-zero `id` is returned.
+- [ ] Given a valid book `id`, when `bookstack_books_read` is called, then a `BookWithContents`
+  JSON object is returned including the `contents` array.
+- [ ] Given a valid book `id` and a changed `name`, when `bookstack_books_update` is called, then
+  the returned `Book` JSON reflects the updated name.
+- [ ] Given a valid book `id`, when `bookstack_books_delete` is called, then a `"Book {id} deleted
+  successfully"` string is returned and a subsequent `bookstack_books_read` with the same `id`
+  returns a 404 error response.
+- [ ] Given a valid book `id` and `format = "html"`, when `bookstack_books_export` is called, then
+  a non-empty HTML string is returned.
+- [ ] Given an `id` of `0`, when any read/update/delete/export tool is called, then an MCP error
+  response containing `"id must be greater than 0"` is returned without making an HTTP call.
+- [ ] Given a non-existent `id`, when `bookstack_books_read` is called, then an MCP error response
+  containing `"Not found"` is returned.
+- [ ] Given chapters, pages, and shelves: all equivalent CRUD criteria above hold for
+  `bookstack_chapters_*`, `bookstack_pages_*`, and `bookstack_shelves_*` tools.
+- [ ] Reading resource `bookstack://books` returns a valid JSON `ListResponse<Book>`.
+- [ ] `dotnet test` passes with zero failures; all new tests use mocked `IBookStackApiClient`.
+
+---
+
+## Security Considerations
+
+- All `id` parameters MUST be validated as positive integers; negative or zero values MUST be
+  rejected before any API call is made (prevents unintended API calls).
+- `name`, `description`, and content fields MUST have length validated per the limits defined in
+  the requirements; oversized inputs are rejected at the MCP boundary (not passed to BookStack).
+- The `format` parameter for export tools MUST be validated against the fixed enum
+  (`html`, `pdf`, `plaintext`, `markdown`); unknown values MUST be rejected.
+- Authentication credentials (`BOOKSTACK_TOKEN_ID`, `BOOKSTACK_TOKEN_SECRET`) are handled
+  exclusively by `AuthenticationHandler` and MUST NOT be logged or returned in tool responses.
+- `BookStackApiException` messages from the API MAY be included in error responses; they MUST NOT
+  include the raw HTTP request (which could contain auth headers).
+
+---
+
+## Open Questions
+
+- Should export tools return raw content (HTML/Markdown string) or wrap it in a JSON envelope?
+  Current preference: raw content, since the MCP client can choose how to display it.
+- Should `bookstack_pages_create` enforce that exactly one of `book_id`/`chapter_id` is provided,
+  or silently accept both and let BookStack decide? Current preference: require at least one,
+  pass both through if provided.

--- a/docs/features/content-tools/plan.md
+++ b/docs/features/content-tools/plan.md
@@ -1,0 +1,947 @@
+# Implementation Plan: Content Tools and Resources — Books, Chapters, Pages, and Shelves CRUD
+
+**Feature**: FEAT-0007
+**Spec**: [docs/features/content-tools/spec.md](spec.md)
+**GitHub Issue**: [#7](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/7)
+**Status**: Ready for implementation
+
+---
+
+## Architecture Decisions
+
+All ADRs for this feature have been accepted. Implementation must follow them without deviation.
+
+| ADR | Title | Decision Summary |
+| --- | --- | --- |
+| [ADR-0001](../../architecture/decisions/ADR-0001-mcp-sdk-selection.md) | MCP SDK Selection | Use `ModelContextProtocol` 1.2.0; attribute-based tool and resource discovery |
+| [ADR-0002](../../architecture/decisions/ADR-0002-solution-structure.md) | Solution and Project Structure | `tools/<entity>/` and `resources/<entity>/` subdirectories; namespaces mirror paths |
+| [ADR-0005](../../architecture/decisions/ADR-0005-ihttpclientfactory-typed-client.md) | IHttpClientFactory Typed Client | Inject `IBookStackApiClient` directly; never construct `HttpClient` in handlers |
+| [ADR-0006](../../architecture/decisions/ADR-0006-systemtextjson-snakecase.md) | System.Text.Json SnakeCaseLower | API client uses `SnakeCaseLower`; do **not** reuse its options in handlers |
+| [ADR-0008](../../architecture/decisions/ADR-0008-bookstackapiexception.md) | Typed Exception — BookStackApiException | `IBookStackApiClient` throws `BookStackApiException`; catch it in handlers, not `HttpRequestException` |
+| [ADR-0010](../../architecture/decisions/ADR-0010-tool-handler-output-json-policy.md) | Tool Handler JSON Output Naming Policy | Use `JsonNamingPolicy.CamelCase` for all tool and resource output; `private static readonly _jsonOptions` per handler class |
+
+---
+
+## Key Code Patterns
+
+These patterns are established in Task 1 and followed identically in Tasks 2–5.
+
+### Shared `_jsonOptions` field
+
+Every handler class declares this field. No external utility class is used.
+
+```csharp
+private static readonly JsonSerializerOptions _jsonOptions = new()
+{
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    WriteIndented = false,
+};
+```
+
+### Error handling shape
+
+All tool methods use this exact try/catch structure. **Catch `BookStackApiException`** (per
+ADR-0008) — not `HttpRequestException`. The spec's code example incorrectly shows
+`HttpRequestException`; the actual exception type is `BookStackApiException`.
+
+```csharp
+try
+{
+    // … build request, call _client, serialize result …
+    return JsonSerializer.Serialize(result, _jsonOptions);
+}
+catch (BookStackApiException ex) when (ex.StatusCode == 404)
+{
+    return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+}
+catch (BookStackApiException ex) when (ex.StatusCode == 422)
+{
+    return JsonSerializer.Serialize(new { error = "validation_error", message = ex.ErrorMessage }, _jsonOptions);
+}
+catch (BookStackApiException ex)
+{
+    _logger.LogError(ex, "BookStack API error: {Message}", ex.Message);
+    return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+}
+```
+
+### ID validation
+
+Applied in every tool method that accepts an `id` parameter before any API call.
+
+```csharp
+if (id <= 0)
+{
+    return JsonSerializer.Serialize(
+        new { error = "validation_error", message = $"id must be a positive integer, got {id}." },
+        _jsonOptions);
+}
+```
+
+### Export format validation and parsing
+
+Applied in `ExportBookAsync`, `ExportChapterAsync`, `ExportPageAsync`.
+
+```csharp
+if (!Enum.TryParse<ExportFormat>(format, ignoreCase: true, out var exportFormat))
+{
+    return JsonSerializer.Serialize(
+        new { error = "validation_error", message = $"Invalid export format '{format}'. Must be one of: html, pdf, plaintext, markdown." },
+        _jsonOptions);
+}
+```
+
+### ListQueryParams construction
+
+Applied in all `ListXxxAsync` methods.
+
+```csharp
+var query = (count.HasValue || offset.HasValue || sort is not null)
+    ? new ListQueryParams { Count = count, Offset = offset, Sort = sort }
+    : null;
+var result = await _client.ListXxxAsync(query, ct).ConfigureAwait(false);
+```
+
+### Delete success response
+
+All delete tools return this structure.
+
+```csharp
+await _client.DeleteXxxAsync(id, ct).ConfigureAwait(false);
+return JsonSerializer.Serialize(new { success = true, message = $"Xxx {id} deleted successfully" }, _jsonOptions);
+```
+
+### Parameter naming note
+
+C# method parameters use camelCase (`bookId`, `descriptionHtml`, `defaultTemplateId`). The MCP SDK
+uses these C# parameter names as JSON schema property names, so MCP clients must send arguments
+with the camelCase keys. This differs from the TypeScript reference implementation which uses
+snake_case (`book_id`). This is intentional for the .NET implementation.
+
+---
+
+## Implementation Tasks
+
+Tasks are ordered by dependency. Each task is independently committable.
+
+---
+
+### Task 1 — Implement `BookToolHandler`
+
+Replace the six `NotImplementedException` stubs with complete implementations. This task also
+establishes the `_jsonOptions` field and error-handling patterns referenced by all subsequent tasks.
+
+**File**: `src/BookStack.Mcp.Server/tools/books/BookToolHandler.cs`
+
+The stubs already store constructor parameters in `_client` and `_logger` backing fields (required
+by `TreatWarningsAsErrors`). No change to field declarations.
+
+Add at the top of the class body:
+
+```csharp
+private static readonly JsonSerializerOptions _jsonOptions = new()
+{
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    WriteIndented = false,
+};
+```
+
+Add required usings:
+
+```csharp
+using System.Net.Http;
+using System.Text.Json;
+using BookStack.Mcp.Server.Api.Models;
+```
+
+#### `ListBooksAsync` — complete signature and body
+
+```csharp
+[McpServerTool(Name = "bookstack_books_list")]
+[Description("List all books visible to the authenticated user with pagination options. Books are the top-level containers in the BookStack content hierarchy.")]
+public async Task<string> ListBooksAsync(
+    [Description("Number of books to return (1–500). Defaults to 20.")] int? count = null,
+    [Description("Number of books to skip for pagination. Defaults to 0.")] int? offset = null,
+    [Description("Sort field: name, created_at, updated_at. Defaults to name.")] string? sort = null,
+    CancellationToken ct = default)
+{
+    try
+    {
+        var query = (count.HasValue || offset.HasValue || sort is not null)
+            ? new ListQueryParams { Count = count, Offset = offset, Sort = sort }
+            : null;
+        var result = await _client.ListBooksAsync(query, ct).ConfigureAwait(false);
+        return JsonSerializer.Serialize(result, _jsonOptions);
+    }
+    catch (BookStackApiException ex) when (ex.StatusCode == 404)
+    {
+        return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+    }
+    catch (BookStackApiException ex) when (ex.StatusCode == 422)
+    {
+        return JsonSerializer.Serialize(new { error = "validation_error", message = ex.ErrorMessage }, _jsonOptions);
+    }
+    catch (BookStackApiException ex)
+    {
+        _logger.LogError(ex, "BookStack API error listing books: {Message}", ex.Message);
+        return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+    }
+}
+```
+
+#### `ReadBookAsync` — complete signature and body
+
+```csharp
+[McpServerTool(Name = "bookstack_books_read")]
+[Description("Get a single book by ID, including its full chapter and page hierarchy.")]
+public async Task<string> ReadBookAsync(
+    [Description("The book ID. Must be a positive integer.")] int id,
+    CancellationToken ct = default)
+{
+    if (id <= 0)
+        return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+    try
+    {
+        var result = await _client.GetBookAsync(id, ct).ConfigureAwait(false);
+        return JsonSerializer.Serialize(result, _jsonOptions);
+    }
+    catch (BookStackApiException ex) when (ex.StatusCode == 404)
+    {
+        return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+    }
+    catch (BookStackApiException ex)
+    {
+        _logger.LogError(ex, "BookStack API error reading book {Id}: {Message}", id, ex.Message);
+        return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+    }
+}
+```
+
+#### `CreateBookAsync` — complete signature and body
+
+```csharp
+[McpServerTool(Name = "bookstack_books_create")]
+[Description("Create a new book. Books are the top-level containers for chapters and pages in BookStack.")]
+public async Task<string> CreateBookAsync(
+    [Description("The book name (required, max 255 characters).")] string name,
+    [Description("Plain text description (max 1900 characters).")] string? description = null,
+    [Description("HTML description (max 2000 characters). Overrides description if both provided.")] string? descriptionHtml = null,
+    [Description("Tags to assign. Each object must have name and value string properties. On update, providing this array replaces ALL existing tags.")] IList<Tag>? tags = null,
+    [Description("ID of a page to use as the default template for new pages in this book.")] int? defaultTemplateId = null,
+    CancellationToken ct = default)
+{
+    try
+    {
+        var request = new CreateBookRequest
+        {
+            Name = name,
+            Description = description,
+            DescriptionHtml = descriptionHtml,
+            Tags = tags,
+            DefaultTemplateId = defaultTemplateId,
+        };
+        var result = await _client.CreateBookAsync(request, ct).ConfigureAwait(false);
+        return JsonSerializer.Serialize(result, _jsonOptions);
+    }
+    catch (BookStackApiException ex) when (ex.StatusCode == 422)
+    {
+        return JsonSerializer.Serialize(new { error = "validation_error", message = ex.ErrorMessage }, _jsonOptions);
+    }
+    catch (BookStackApiException ex)
+    {
+        _logger.LogError(ex, "BookStack API error creating book: {Message}", ex.Message);
+        return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+    }
+}
+```
+
+#### `UpdateBookAsync` — complete signature and body
+
+```csharp
+[McpServerTool(Name = "bookstack_books_update")]
+[Description("Update an existing book's name, description, or tags.")]
+public async Task<string> UpdateBookAsync(
+    [Description("The book ID. Must be a positive integer.")] int id,
+    [Description("New name for the book (max 255 characters).")] string? name = null,
+    [Description("Plain text description (max 1900 characters).")] string? description = null,
+    [Description("HTML description (max 2000 characters). Overrides description if both provided.")] string? descriptionHtml = null,
+    [Description("Tags to assign. Providing this array replaces ALL existing tags. Omit to leave tags unchanged.")] IList<Tag>? tags = null,
+    [Description("ID of a page to use as the default template for new pages in this book.")] int? defaultTemplateId = null,
+    CancellationToken ct = default)
+{
+    if (id <= 0)
+        return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+    try
+    {
+        var request = new UpdateBookRequest
+        {
+            Name = name,
+            Description = description,
+            DescriptionHtml = descriptionHtml,
+            Tags = tags,
+            DefaultTemplateId = defaultTemplateId,
+        };
+        var result = await _client.UpdateBookAsync(id, request, ct).ConfigureAwait(false);
+        return JsonSerializer.Serialize(result, _jsonOptions);
+    }
+    catch (BookStackApiException ex) when (ex.StatusCode == 404)
+    {
+        return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+    }
+    catch (BookStackApiException ex) when (ex.StatusCode == 422)
+    {
+        return JsonSerializer.Serialize(new { error = "validation_error", message = ex.ErrorMessage }, _jsonOptions);
+    }
+    catch (BookStackApiException ex)
+    {
+        _logger.LogError(ex, "BookStack API error updating book {Id}: {Message}", id, ex.Message);
+        return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+    }
+}
+```
+
+#### `DeleteBookAsync` — complete signature and body
+
+```csharp
+[McpServerTool(Name = "bookstack_books_delete")]
+[Description("Delete a book by ID. This moves the book and all its contents to the recycle bin.")]
+public async Task<string> DeleteBookAsync(
+    [Description("The book ID. Must be a positive integer.")] int id,
+    CancellationToken ct = default)
+{
+    if (id <= 0)
+        return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+    try
+    {
+        await _client.DeleteBookAsync(id, ct).ConfigureAwait(false);
+        return JsonSerializer.Serialize(new { success = true, message = $"Book {id} deleted successfully" }, _jsonOptions);
+    }
+    catch (BookStackApiException ex) when (ex.StatusCode == 404)
+    {
+        return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+    }
+    catch (BookStackApiException ex)
+    {
+        _logger.LogError(ex, "BookStack API error deleting book {Id}: {Message}", id, ex.Message);
+        return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+    }
+}
+```
+
+#### `ExportBookAsync` — complete signature and body
+
+```csharp
+[McpServerTool(Name = "bookstack_books_export")]
+[Description("Export a book in the specified format. Returns the raw export content as a string.")]
+public async Task<string> ExportBookAsync(
+    [Description("The book ID. Must be a positive integer.")] int id,
+    [Description("Export format. Must be one of: html, pdf, plaintext, markdown.")] string format,
+    CancellationToken ct = default)
+{
+    if (id <= 0)
+        return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+    if (!Enum.TryParse<ExportFormat>(format, ignoreCase: true, out var exportFormat))
+        return JsonSerializer.Serialize(
+            new { error = "validation_error", message = $"Invalid export format '{format}'. Must be one of: html, pdf, plaintext, markdown." },
+            _jsonOptions);
+    try
+    {
+        return await _client.ExportBookAsync(id, exportFormat, ct).ConfigureAwait(false);
+    }
+    catch (BookStackApiException ex) when (ex.StatusCode == 404)
+    {
+        return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+    }
+    catch (BookStackApiException ex)
+    {
+        _logger.LogError(ex, "BookStack API error exporting book {Id}: {Message}", id, ex.Message);
+        return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+    }
+}
+```
+
+**Acceptance**:
+
+- `dotnet build` succeeds with zero errors and zero warnings.
+- No method throws `NotImplementedException`.
+- All six methods appear in `tools/list` response with accurate names and non-empty descriptions.
+
+---
+
+### Task 2 — Implement `ChapterToolHandler`
+
+Replace the six stubs in `src/BookStack.Mcp.Server/tools/chapters/ChapterToolHandler.cs`.
+Follow the identical `_jsonOptions`, error-handling, and `ConfigureAwait(false)` patterns from
+Task 1. Add the same usings.
+
+#### Full method signatures
+
+```csharp
+[McpServerTool(Name = "bookstack_chapters_list")]
+[Description("List all chapters visible to the authenticated user with pagination options.")]
+public async Task<string> ListChaptersAsync(
+    [Description("Number of chapters to return (1–500). Defaults to 20.")] int? count = null,
+    [Description("Number of chapters to skip for pagination. Defaults to 0.")] int? offset = null,
+    [Description("Sort field: name, created_at, updated_at. Defaults to name.")] string? sort = null,
+    CancellationToken ct = default)
+
+[McpServerTool(Name = "bookstack_chapters_read")]
+[Description("Get a single chapter by ID, including its list of pages.")]
+public async Task<string> ReadChapterAsync(
+    [Description("The chapter ID. Must be a positive integer.")] int id,
+    CancellationToken ct = default)
+
+[McpServerTool(Name = "bookstack_chapters_create")]
+[Description("Create a new chapter inside a book.")]
+public async Task<string> CreateChapterAsync(
+    [Description("ID of the book that will contain this chapter. Must be a positive integer.")] int bookId,
+    [Description("The chapter name (required, max 255 characters).")] string name,
+    [Description("Plain text description (max 1900 characters).")] string? description = null,
+    [Description("HTML description (max 2000 characters). Overrides description if both provided.")] string? descriptionHtml = null,
+    [Description("Tags to assign. Each object must have name and value string properties.")] IList<Tag>? tags = null,
+    CancellationToken ct = default)
+
+[McpServerTool(Name = "bookstack_chapters_update")]
+[Description("Update an existing chapter's name, description, tags, or move it to a different book.")]
+public async Task<string> UpdateChapterAsync(
+    [Description("The chapter ID. Must be a positive integer.")] int id,
+    [Description("Move the chapter to a different book by specifying the target book ID.")] int? bookId = null,
+    [Description("New name for the chapter (max 255 characters).")] string? name = null,
+    [Description("Plain text description (max 1900 characters).")] string? description = null,
+    [Description("HTML description (max 2000 characters). Overrides description if both provided.")] string? descriptionHtml = null,
+    [Description("Tags to assign. Providing this array replaces ALL existing tags. Omit to leave tags unchanged.")] IList<Tag>? tags = null,
+    CancellationToken ct = default)
+
+[McpServerTool(Name = "bookstack_chapters_delete")]
+[Description("Delete a chapter by ID. This moves the chapter and all its pages to the recycle bin.")]
+public async Task<string> DeleteChapterAsync(
+    [Description("The chapter ID. Must be a positive integer.")] int id,
+    CancellationToken ct = default)
+
+[McpServerTool(Name = "bookstack_chapters_export")]
+[Description("Export a chapter in the specified format. Returns the raw export content as a string.")]
+public async Task<string> ExportChapterAsync(
+    [Description("The chapter ID. Must be a positive integer.")] int id,
+    [Description("Export format. Must be one of: html, pdf, plaintext, markdown.")] string format,
+    CancellationToken ct = default)
+```
+
+#### Key implementation notes
+
+- `CreateChapterAsync`: validate `bookId > 0` before building `CreateChapterRequest`.
+- `UpdateChapterAsync`: validate `id > 0`. If `bookId` is provided, also validate `bookId > 0`.
+- `DeleteChapterAsync`: success message is `$"Chapter {id} deleted successfully"`.
+- Log message prefix: `"BookStack API error listing/reading/creating/updating/deleting/exporting chapter …"`.
+
+**Acceptance**: All six chapter tools appear in `tools/list`; `dotnet build` passes.
+
+---
+
+### Task 3 — Implement `PageToolHandler`
+
+Replace the six stubs in `src/BookStack.Mcp.Server/tools/pages/PageToolHandler.cs`.
+Follow identical patterns from Task 1. The `bookstack_pages_create` method has an additional
+validation step.
+
+#### Full method signatures
+
+```csharp
+[McpServerTool(Name = "bookstack_pages_list")]
+[Description("List all pages visible to the authenticated user with pagination options.")]
+public async Task<string> ListPagesAsync(
+    [Description("Number of pages to return (1–500). Defaults to 20.")] int? count = null,
+    [Description("Number of pages to skip for pagination. Defaults to 0.")] int? offset = null,
+    [Description("Sort field: name, created_at, updated_at. Defaults to name.")] string? sort = null,
+    CancellationToken ct = default)
+
+[McpServerTool(Name = "bookstack_pages_read")]
+[Description("Get a single page by ID, including its HTML and Markdown content.")]
+public async Task<string> ReadPageAsync(
+    [Description("The page ID. Must be a positive integer.")] int id,
+    CancellationToken ct = default)
+
+[McpServerTool(Name = "bookstack_pages_create")]
+[Description("Create a new page. Either bookId or chapterId must be provided to specify where the page is created.")]
+public async Task<string> CreatePageAsync(
+    [Description("The page name (required, max 255 characters).")] string name,
+    [Description("ID of the book to create the page in. Required if chapterId is not provided.")] int? bookId = null,
+    [Description("ID of the chapter to create the page in. Required if bookId is not provided.")] int? chapterId = null,
+    [Description("HTML content for the page.")] string? html = null,
+    [Description("Markdown content for the page. If both html and markdown are provided, html takes precedence.")] string? markdown = null,
+    [Description("Tags to assign. Each object must have name and value string properties.")] IList<Tag>? tags = null,
+    CancellationToken ct = default)
+
+[McpServerTool(Name = "bookstack_pages_update")]
+[Description("Update an existing page's name, content, tags, or move it to a different book or chapter.")]
+public async Task<string> UpdatePageAsync(
+    [Description("The page ID. Must be a positive integer.")] int id,
+    [Description("New name for the page (max 255 characters).")] string? name = null,
+    [Description("Move the page to a different book.")] int? bookId = null,
+    [Description("Move the page to a different chapter.")] int? chapterId = null,
+    [Description("HTML content for the page.")] string? html = null,
+    [Description("Markdown content for the page.")] string? markdown = null,
+    [Description("Tags to assign. Providing this array replaces ALL existing tags. Omit to leave tags unchanged.")] IList<Tag>? tags = null,
+    CancellationToken ct = default)
+
+[McpServerTool(Name = "bookstack_pages_delete")]
+[Description("Delete a page by ID. This moves the page to the recycle bin.")]
+public async Task<string> DeletePageAsync(
+    [Description("The page ID. Must be a positive integer.")] int id,
+    CancellationToken ct = default)
+
+[McpServerTool(Name = "bookstack_pages_export")]
+[Description("Export a page in the specified format. Returns the raw export content as a string.")]
+public async Task<string> ExportPageAsync(
+    [Description("The page ID. Must be a positive integer.")] int id,
+    [Description("Export format. Must be one of: html, pdf, plaintext, markdown.")] string format,
+    CancellationToken ct = default)
+```
+
+#### Key implementation notes
+
+- `CreatePageAsync` — parent validation before API call:
+
+```csharp
+if (bookId is null && chapterId is null)
+{
+    return JsonSerializer.Serialize(
+        new { error = "validation_error", message = "Either bookId or chapterId is required." },
+        _jsonOptions);
+}
+```
+
+  If both are provided, pass both to `CreatePageRequest`; the BookStack API resolves precedence.
+
+- `CreatePageRequest` field mapping:
+
+```csharp
+var request = new CreatePageRequest
+{
+    Name = name,
+    BookId = bookId,
+    ChapterId = chapterId,
+    Html = html,
+    Markdown = markdown,
+    Tags = tags,
+};
+```
+
+- `DeletePageAsync`: success message is `$"Page {id} deleted successfully"`.
+
+**Acceptance**: All six page tools appear in `tools/list`; `dotnet build` passes.
+
+---
+
+### Task 4 — Implement `ShelfToolHandler`
+
+Replace the five stubs in `src/BookStack.Mcp.Server/tools/shelves/ShelfToolHandler.cs`.
+Follow identical patterns from Task 1. There is no export tool for shelves.
+
+#### Full method signatures
+
+```csharp
+[McpServerTool(Name = "bookstack_shelves_list")]
+[Description("List all bookshelves visible to the authenticated user with pagination options. Shelves group related books into collections.")]
+public async Task<string> ListShelvesAsync(
+    [Description("Number of shelves to return (1–500). Defaults to 20.")] int? count = null,
+    [Description("Number of shelves to skip for pagination. Defaults to 0.")] int? offset = null,
+    [Description("Sort field: name, created_at, updated_at. Defaults to name.")] string? sort = null,
+    CancellationToken ct = default)
+
+[McpServerTool(Name = "bookstack_shelves_read")]
+[Description("Get a single bookshelf by ID, including the list of books assigned to it.")]
+public async Task<string> ReadShelfAsync(
+    [Description("The shelf ID. Must be a positive integer.")] int id,
+    CancellationToken ct = default)
+
+[McpServerTool(Name = "bookstack_shelves_create")]
+[Description("Create a new bookshelf. Optionally assign books to the shelf at creation time.")]
+public async Task<string> CreateShelfAsync(
+    [Description("The shelf name (required, max 255 characters).")] string name,
+    [Description("Plain text description (max 1900 characters).")] string? description = null,
+    [Description("HTML description (max 2000 characters). Overrides description if both provided.")] string? descriptionHtml = null,
+    [Description("Tags to assign. Each object must have name and value string properties.")] IList<Tag>? tags = null,
+    [Description("List of book IDs to assign to this shelf. Providing this array on update replaces ALL currently assigned books.")] IList<int>? books = null,
+    CancellationToken ct = default)
+
+[McpServerTool(Name = "bookstack_shelves_update")]
+[Description("Update an existing shelf's name, description, tags, or assigned books.")]
+public async Task<string> UpdateShelfAsync(
+    [Description("The shelf ID. Must be a positive integer.")] int id,
+    [Description("New name for the shelf (max 255 characters).")] string? name = null,
+    [Description("Plain text description (max 1900 characters).")] string? description = null,
+    [Description("HTML description (max 2000 characters). Overrides description if both provided.")] string? descriptionHtml = null,
+    [Description("Tags to assign. Providing this array replaces ALL existing tags. Omit to leave tags unchanged.")] IList<Tag>? tags = null,
+    [Description("List of book IDs to assign to this shelf. Providing this array replaces ALL currently assigned books. Omit to leave books unchanged.")] IList<int>? books = null,
+    CancellationToken ct = default)
+
+[McpServerTool(Name = "bookstack_shelves_delete")]
+[Description("Delete a bookshelf by ID. The shelf's assigned books are NOT deleted.")]
+public async Task<string> DeleteShelfAsync(
+    [Description("The shelf ID. Must be a positive integer.")] int id,
+    CancellationToken ct = default)
+```
+
+#### Key implementation notes
+
+- `CreateShelfAsync` request mapping:
+
+```csharp
+var request = new CreateShelfRequest
+{
+    Name = name,
+    Description = description,
+    DescriptionHtml = descriptionHtml,
+    Tags = tags,
+    Books = books,
+};
+```
+
+- `UpdateShelfAsync` request mapping:
+
+```csharp
+var request = new UpdateShelfRequest
+{
+    Name = name,
+    Description = description,
+    DescriptionHtml = descriptionHtml,
+    Tags = tags,
+    Books = books,
+};
+```
+
+- `DeleteShelfAsync`: success message is `$"Shelf {id} deleted successfully"`.
+
+**Acceptance**: All five shelf tools appear in `tools/list`; `dotnet build` passes.
+
+---
+
+### Task 5 — Implement Resource Handlers
+
+Each handler requires two changes:
+
+1. Replace the `NotImplementedException` in the existing **collection** resource method.
+2. Add a new **individual-item** resource method with a `{id}` URI template.
+
+Resource handlers also declare `_jsonOptions` (same definition as tools) and catch
+`BookStackApiException` for error handling. Resource methods do not need ID validation because
+the URI template binding is handled by the SDK before the method is invoked; an invalid URI simply
+will not match the template.
+
+#### `src/BookStack.Mcp.Server/resources/books/BookResourceHandler.cs`
+
+Add `_jsonOptions`, usings, and implement:
+
+```csharp
+[McpServerResource(UriTemplate = "bookstack://books", Name = "Books")]
+[Description("All books visible to the authenticated user.")]
+public async Task<string> GetBooksAsync(CancellationToken ct = default)
+{
+    var result = await _client.ListBooksAsync(null, ct).ConfigureAwait(false);
+    return JsonSerializer.Serialize(result, _jsonOptions);
+}
+
+[McpServerResource(UriTemplate = "bookstack://books/{id}", Name = "Book")]
+[Description("A single book including its chapter and page hierarchy.")]
+public async Task<string> GetBookAsync(
+    [Description("The book ID.")] int id,
+    CancellationToken ct = default)
+{
+    var result = await _client.GetBookAsync(id, ct).ConfigureAwait(false);
+    return JsonSerializer.Serialize(result, _jsonOptions);
+}
+```
+
+Both methods wrap in try/catch following the error handling shape from Task 1 (omit 422 catch, as
+resource reads do not perform writes). The `GetBooksAsync` catch omits the 404 branch as a list
+call does not return 404.
+
+#### `src/BookStack.Mcp.Server/resources/chapters/ChapterResourceHandler.cs`
+
+```csharp
+[McpServerResource(UriTemplate = "bookstack://chapters", Name = "Chapters")]
+[Description("All chapters visible to the authenticated user.")]
+public async Task<string> GetChaptersAsync(CancellationToken ct = default)
+
+[McpServerResource(UriTemplate = "bookstack://chapters/{id}", Name = "Chapter")]
+[Description("A single chapter including its list of pages.")]
+public async Task<string> GetChapterAsync(
+    [Description("The chapter ID.")] int id,
+    CancellationToken ct = default)
+```
+
+#### `src/BookStack.Mcp.Server/resources/pages/PageResourceHandler.cs`
+
+```csharp
+[McpServerResource(UriTemplate = "bookstack://pages", Name = "Pages")]
+[Description("All pages visible to the authenticated user.")]
+public async Task<string> GetPagesAsync(CancellationToken ct = default)
+
+[McpServerResource(UriTemplate = "bookstack://pages/{id}", Name = "Page")]
+[Description("A single page including its HTML and Markdown content.")]
+public async Task<string> GetPageAsync(
+    [Description("The page ID.")] int id,
+    CancellationToken ct = default)
+```
+
+#### `src/BookStack.Mcp.Server/resources/shelves/ShelfResourceHandler.cs`
+
+```csharp
+[McpServerResource(UriTemplate = "bookstack://shelves", Name = "Shelves")]
+[Description("All bookshelves visible to the authenticated user.")]
+public async Task<string> GetShelvesAsync(CancellationToken ct = default)
+
+[McpServerResource(UriTemplate = "bookstack://shelves/{id}", Name = "Shelf")]
+[Description("A single bookshelf including its list of assigned books.")]
+public async Task<string> GetShelfAsync(
+    [Description("The shelf ID.")] int id,
+    CancellationToken ct = default)
+```
+
+**Acceptance**:
+
+- All 8 resources appear in `resources/list` with correct `uriTemplate` values.
+- `bookstack://books/{id}` and the three equivalent item templates appear as resource templates
+  (distinguishable from static resources in the MCP protocol response).
+- `dotnet build` passes.
+
+---
+
+### Task 6 — Tests: `BookToolHandlerTests`
+
+**File**: `tests/BookStack.Mcp.Server.Tests/tools/books/BookToolHandlerTests.cs`
+
+**Namespace**: `BookStack.Mcp.Server.Tests.Tools.Books`
+
+**Setup pattern** (used across all tool handler test files):
+
+```csharp
+using Moq;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Text.Json;
+using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Tools.Books;
+
+public sealed class BookToolHandlerTests
+{
+    private readonly Mock<IBookStackApiClient> _client = new();
+    private readonly BookToolHandler _handler;
+
+    public BookToolHandlerTests()
+    {
+        _handler = new BookToolHandler(_client.Object, NullLogger<BookToolHandler>.Instance);
+    }
+}
+```
+
+#### Test cases (10)
+
+1. **`ListBooksAsync_NoParams_CallsClientWithNullQuery`**
+   - Arrange: `_client.Setup(c => c.ListBooksAsync(null, It.IsAny<CancellationToken>())).ReturnsAsync(new ListResponse<Book>())`
+   - Act: call `ListBooksAsync()` with no arguments
+   - Assert: `_client.Verify(c => c.ListBooksAsync(null, It.IsAny<CancellationToken>()), Times.Once)`
+
+2. **`ListBooksAsync_WithCountAndOffset_PassesParams`**
+   - Arrange: mock returns empty `ListResponse<Book>`
+   - Act: call `ListBooksAsync(count: 5, offset: 10)`
+   - Assert: verify `ListBooksAsync` called with `ListQueryParams` where `Count == 5` and `Offset == 10`
+   - Use `It.Is<ListQueryParams?>(q => q != null && q.Count == 5 && q.Offset == 10)`
+
+3. **`ReadBookAsync_ValidId_ReturnsSerializedBook`**
+   - Arrange: mock `GetBookAsync(42, …)` returns a `BookWithContents { Id = 42 }`
+   - Act: call `ReadBookAsync(42)`
+   - Assert: result is valid JSON; `JsonDocument.Parse(result).RootElement.GetProperty("id").GetInt32()` equals `42`
+
+4. **`ReadBookAsync_NotFound_ReturnsErrorJson`**
+   - Arrange: mock throws `new BookStackApiException(404, "Not found", null)`
+   - Act: call `ReadBookAsync(999)`
+   - Assert: result JSON has `error == "not_found"`; no exception thrown
+
+5. **`CreateBookAsync_ValidName_ReturnsSerializedBook`**
+   - Arrange: mock `CreateBookAsync` returns `new Book { Id = 1, Name = "Test" }`
+   - Act: call `CreateBookAsync("Test")`
+   - Assert: result JSON has `name == "Test"`
+   - Also assert: `_client.Verify(c => c.CreateBookAsync(It.Is<CreateBookRequest>(r => r.Name == "Test"), …))`
+
+6. **`CreateBookAsync_WithTags_PassesTagsToRequest`**
+   - Arrange: mock returns `new Book { Id = 1, Name = "T" }`
+   - Act: call `CreateBookAsync("T", tags: [new Tag { Name = "env", Value = "prod" }])`
+   - Assert: verify `CreateBookRequest.Tags` has one element with `Name == "env"`
+
+7. **`UpdateBookAsync_ValidId_ReturnsUpdatedBook`**
+   - Arrange: mock `UpdateBookAsync(5, …)` returns `new Book { Id = 5, Name = "Updated" }`
+   - Act: call `UpdateBookAsync(5, name: "Updated")`
+   - Assert: result JSON has `name == "Updated"`
+
+8. **`DeleteBookAsync_ValidId_ReturnsSuccessJson`**
+   - Arrange: mock `DeleteBookAsync(3, …)` returns `Task.CompletedTask`
+   - Act: call `DeleteBookAsync(3)`
+   - Assert: result JSON has `success == true`; message contains `"3"`
+
+9. **`ExportBookAsync_InvalidFormat_ReturnsValidationError`**
+   - Arrange: no mock setup needed (validation fires before API call)
+   - Act: call `ExportBookAsync(1, "docx")`
+   - Assert: result JSON has `error == "validation_error"`; `_client` not called
+
+10. **`ExportBookAsync_ValidFormatMarkdown_ReturnsExportString`**
+    - Arrange: mock `ExportBookAsync(1, ExportFormat.Markdown, …)` returns `"# My Book"`
+    - Act: call `ExportBookAsync(1, "markdown")`
+    - Assert: result equals `"# My Book"` (raw string, not JSON)
+
+**Acceptance**: `dotnet test` passes all 10 tests; no real HTTP calls made.
+
+---
+
+### Task 7 — Tests: Chapter, Page, and Shelf Tool Handlers
+
+Three test files, one per handler. Follow the same setup pattern from Task 6.
+
+#### `tests/BookStack.Mcp.Server.Tests/tools/chapters/ChapterToolHandlerTests.cs`
+
+Test cases (3):
+
+11. **`CreateChapterAsync_ValidBookIdAndName_ReturnsSerializedChapter`**
+    - Arrange: mock returns `new Chapter { Id = 10, BookId = 2, Name = "Ch1" }`
+    - Act: call `CreateChapterAsync(bookId: 2, name: "Ch1")`
+    - Assert: result JSON has `bookId == 2`; verify `CreateChapterRequest { BookId = 2, Name = "Ch1" }`
+
+12. **`ReadChapterAsync_NotFound_ReturnsErrorJson`**
+    - Arrange: mock throws `new BookStackApiException(404, "Not found", null)`
+    - Act: call `ReadChapterAsync(999)`
+    - Assert: result JSON has `error == "not_found"`; no exception
+
+13. **`DeleteChapterAsync_ValidId_ReturnsSuccessJson`**
+    - Arrange: mock `DeleteChapterAsync(7, …)` returns `Task.CompletedTask`
+    - Act: call `DeleteChapterAsync(7)`
+    - Assert: result JSON has `success == true`; message contains `"7"`
+
+#### `tests/BookStack.Mcp.Server.Tests/tools/pages/PageToolHandlerTests.cs`
+
+Test cases (5):
+
+14. **`CreatePageAsync_NoParentId_ReturnsValidationError`**
+    - Arrange: no mock setup
+    - Act: call `CreatePageAsync("Page1")` (no `bookId`, no `chapterId`)
+    - Assert: result JSON has `error == "validation_error"`; message contains `"bookId"` or `"chapterId"`; client not called
+
+15. **`CreatePageAsync_WithBookId_CallsClientWithCorrectRequest`**
+    - Arrange: mock returns `new Page { Id = 5, BookId = 3 }`
+    - Act: call `CreatePageAsync("Page1", bookId: 3)`
+    - Assert: verify `CreatePageRequest { BookId = 3, Name = "Page1" }`; `ChapterId` is `null`
+
+16. **`CreatePageAsync_WithMarkdown_SetsMarkdownField`**
+    - Arrange: mock returns `new Page { Id = 6 }`
+    - Act: call `CreatePageAsync("Md Page", chapterId: 1, markdown: "# Hello")`
+    - Assert: verify `CreatePageRequest { Markdown = "# Hello", Html = null }`
+
+17. **`ReadPageAsync_ValidId_ReturnsPageWithContent`**
+    - Arrange: mock `GetPageAsync(8, …)` returns `new PageWithContent { Id = 8, Html = "<p>Hi</p>" }`
+    - Act: call `ReadPageAsync(8)`
+    - Assert: result JSON has `html == "<p>Hi</p>"`
+
+18. **`DeletePageAsync_NotFound_ReturnsErrorJson`**
+    - Arrange: mock throws `new BookStackApiException(404, "Not found", null)`
+    - Act: call `DeletePageAsync(99)`
+    - Assert: result JSON has `error == "not_found"`; no exception
+
+#### `tests/BookStack.Mcp.Server.Tests/tools/shelves/ShelfToolHandlerTests.cs`
+
+Test cases (3):
+
+19. **`CreateShelfAsync_WithBooks_SetsBooksList`**
+    - Arrange: mock returns `new Bookshelf { Id = 4, Name = "My Shelf" }`
+    - Act: call `CreateShelfAsync("My Shelf", books: [1, 2, 3])`
+    - Assert: verify `CreateShelfRequest { Books = [1, 2, 3] }`
+
+20. **`UpdateShelfAsync_WithBooks_ReplacesExistingBooks`**
+    - Arrange: mock `UpdateShelfAsync(4, …)` returns `new Bookshelf { Id = 4 }`
+    - Act: call `UpdateShelfAsync(4, books: [5])`
+    - Assert: verify `UpdateShelfRequest { Books = [5] }`
+
+21. **`DeleteShelfAsync_ValidId_ReturnsSuccessJson`**
+    - Arrange: mock `DeleteShelfAsync(4, …)` returns `Task.CompletedTask`
+    - Act: call `DeleteShelfAsync(4)`
+    - Assert: result JSON has `success == true`; message contains `"4"`
+
+**Acceptance**: `dotnet test` passes all 11 tests; no real HTTP calls made.
+
+---
+
+### Task 8 — Tests: Resource Handlers
+
+Two test files covering the four resource handlers. Resource handler tests mock
+`IBookStackApiClient` the same way as tool handler tests.
+
+#### `tests/BookStack.Mcp.Server.Tests/resources/books/BookResourceHandlerTests.cs`
+
+Setup:
+
+```csharp
+private readonly Mock<IBookStackApiClient> _client = new();
+private readonly BookResourceHandler _handler;
+
+public BookResourceHandlerTests()
+{
+    _handler = new BookResourceHandler(_client.Object, NullLogger<BookResourceHandler>.Instance);
+}
+```
+
+Test cases (2):
+
+22. **`GetBooksResource_ReturnsSerializedListResponse`**
+    - Arrange: mock `ListBooksAsync(null, …)` returns `new ListResponse<Book> { Data = [new Book { Id = 1 }], Total = 1 }`
+    - Act: call `GetBooksAsync()`
+    - Assert: result is valid JSON with `total == 1`; `data` array has one element
+
+23. **`GetBookByIdResource_ValidId_ReturnsSerializedBookWithContents`**
+    - Arrange: mock `GetBookAsync(7, …)` returns `new BookWithContents { Id = 7 }`
+    - Act: call `GetBookAsync(7)`
+    - Assert: result JSON has `id == 7`
+
+#### `tests/BookStack.Mcp.Server.Tests/resources/pages/PageResourceHandlerTests.cs`
+
+Test cases (2):
+
+24. **`GetPagesResource_ReturnsSerializedListResponse`**
+    - Arrange: mock `ListPagesAsync(null, …)` returns `new ListResponse<Page> { Data = [new Page { Id = 3 }], Total = 1 }`
+    - Act: call `GetPagesAsync()`
+    - Assert: result JSON with `total == 1`
+
+25. **`GetPageByIdResource_ValidId_ReturnsSerializedPageWithContent`**
+    - Arrange: mock `GetPageAsync(3, …)` returns `new PageWithContent { Id = 3, Html = "<p>Content</p>" }`
+    - Act: call `GetPageAsync(3)`
+    - Assert: result JSON has `html == "<p>Content</p>"`
+
+**Acceptance**: `dotnet test` passes all 25 test cases across all 8 test files; no real HTTP calls.
+
+---
+
+## Commands
+
+Executable commands for this project (copy and run directly):
+
+### Build
+
+```
+dotnet build src/BookStack.Mcp.Server/BookStack.Mcp.Server.csproj --configuration Release
+```
+
+### Tests
+
+```
+dotnet test tests/BookStack.Mcp.Server.Tests/BookStack.Mcp.Server.Tests.csproj --verbosity normal
+```
+
+### Lint / Formatting
+
+```
+dotnet format src/BookStack.Mcp.Server/BookStack.Mcp.Server.csproj --verify-no-changes
+```
+
+### Local Execution (stdio)
+
+```
+BOOKSTACK_BASE_URL=http://localhost BOOKSTACK_TOKEN_ID=tid BOOKSTACK_TOKEN_SECRET=sec dotnet run --project src/BookStack.Mcp.Server
+```

--- a/docs/features/content-tools/spec.md
+++ b/docs/features/content-tools/spec.md
@@ -1,0 +1,506 @@
+# Feature Spec: Content Tools and Resources — Books, Chapters, Pages, and Shelves CRUD
+
+**ID**: FEAT-0007
+**Status**: Draft
+**Author**: GitHub Copilot
+**Created**: 2026-04-20
+**Last Updated**: 2026-04-20
+**GitHub Issue**: [#7 — Books, Chapters, Pages, and Shelves CRUD tool implementations](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/7)
+**Parent Epic**: [#1 — Core MCP Server](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/1)
+**Related ADRs**:
+[ADR-0001](../../architecture/decisions/ADR-0001-mcp-sdk-selection.md),
+[ADR-0002](../../architecture/decisions/ADR-0002-solution-structure.md),
+[ADR-0005](../../architecture/decisions/ADR-0005-ihttpclientfactory-typed-client.md)
+
+---
+
+## Executive Summary
+
+- **Objective**: Replace the `NotImplementedException` stubs in `BookToolHandler`, `ChapterToolHandler`,
+  `PageToolHandler`, and `ShelfToolHandler` — and their corresponding resource handlers — with fully working
+  implementations that delegate to `IBookStackApiClient` and return JSON-serialized results to MCP clients.
+- **Primary user**: MCP clients (LLM agents, Claude Desktop) that need to read, create, update, delete, and
+  export BookStack content.
+- **Value delivered**: 23 operational MCP tools and 8 MCP resources covering the four core BookStack
+  content-hierarchy entities, unblocking all knowledge-management workflows for AI agents.
+- **Scope**: `BookToolHandler`, `ChapterToolHandler`, `PageToolHandler`, `ShelfToolHandler`,
+  `BookResourceHandler`, `ChapterResourceHandler`, `PageResourceHandler`, and `ShelfResourceHandler`.
+  No new API client methods, no schema migrations, no authentication changes.
+- **Primary success criterion**: Every tool listed in this spec returns a valid JSON string (not an exception)
+  when called with valid parameters, and returns a structured error message for invalid inputs.
+
+---
+
+## Problem Statement
+
+The MCP server infrastructure (FEAT-0008) registered stub tool and resource handlers so that
+`tools/list` and `resources/list` return complete descriptors. However, calling any content tool
+currently throws `NotImplementedException`, making the server unusable for its primary purpose of
+providing AI agents with access to BookStack content. `IBookStackApiClient` (FEAT-0018) already
+implements all required HTTP calls; this feature simply wires the MCP tool layer to the client.
+
+## Goals
+
+1. Implement all 23 content CRUD tools (6 each for Books, Chapters, and Pages; 5 for Shelves) so
+   they proxy to `IBookStackApiClient` and return serialized JSON strings.
+2. Implement all 8 content resources (collection and individual-item URIs for each entity) so they
+   return the same serialized JSON format as the corresponding read tools.
+3. Provide correct, descriptive `[Description]` attributes on every tool parameter so that MCP
+   clients can discover parameter semantics without consulting external documentation.
+4. Handle all foreseeable error conditions (resource-not-found, validation errors, API connectivity
+   failures) with structured error messages rather than unhandled exceptions.
+
+## Non-Goals
+
+- Implementing tools for Users, Roles, Attachments, Images, Search, Recycle Bin, Permissions,
+  Audit Log, or System Info (covered by separate issues).
+- Adding new methods to `IBookStackApiClient` or changing existing API model types.
+- Adding pagination cursor support beyond `count`/`offset` (BookStack API v25 only supports offset pagination).
+- Image upload for cover images (`imageId` parameter) on Create/Update book and shelf calls.
+- Implementing server-side caching of BookStack API responses.
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+1. Each of the 23 tool handler methods MUST replace its `NotImplementedException` stub with a
+   complete implementation that constructs the appropriate request model, calls the corresponding
+   `IBookStackApiClient` method, and returns the result serialized as a JSON string.
+2. All tool methods that accept an `id` parameter MUST validate that the value is a positive integer
+   and return a descriptive error string (not throw) when the constraint is violated.
+3. `bookstack_pages_create` MUST validate that exactly one of `book_id` or `chapter_id` is provided,
+   and return a validation error string if neither is supplied.
+4. `bookstack_books_export`, `bookstack_chapters_export`, and `bookstack_pages_export` MUST validate
+   that `format` is one of `html`, `pdf`, `plaintext`, or `markdown`; invalid values MUST return a
+   descriptive error string.
+5. Tag arrays MUST be accepted as an optional list of `{name, value}` objects on all create and
+   update operations; when omitted, no tags are set on create and existing tags are unchanged on update.
+   When provided on an update, they MUST replace all existing tags (BookStack API behavior).
+6. The `books` array on `bookstack_shelves_create` and `bookstack_shelves_update` MUST accept a list
+   of book IDs; when provided on an update, it MUST replace all books currently assigned to the shelf.
+7. All list tools MUST pass `count`, `offset`, and `sort` to `ListQueryParams` when the caller
+   provides them; omitted parameters MUST be left `null` so that the BookStack API applies its own
+   defaults (count=20, offset=0, sort=name).
+8. When `IBookStackApiClient` throws `HttpRequestException` with a 404 status code, the tool MUST
+   return a JSON error object `{"error": "not_found", "message": "…"}` rather than propagating the
+   exception.
+9. When `IBookStackApiClient` throws `HttpRequestException` with a 422 status code, the tool MUST
+   return a JSON error object `{"error": "validation_error", "message": "…"}` rather than propagating.
+10. When `IBookStackApiClient` throws any other `HttpRequestException`, the tool MUST log the error
+    at `Error` level via `ILogger<T>` and return a JSON error object
+    `{"error": "api_error", "message": "…"}`.
+11. Delete tools (`bookstack_books_delete`, `bookstack_chapters_delete`, `bookstack_pages_delete`,
+    `bookstack_shelves_delete`) MUST return `{"success": true, "message": "… deleted successfully"}`
+    on success.
+12. Export tools MUST return the raw export content (HTML string, Markdown string, plain text string,
+    or base64-encoded PDF) unchanged as the tool result string.
+13. Each `BookResourceHandler`, `ChapterResourceHandler`, `PageResourceHandler`, and
+    `ShelfResourceHandler` MUST implement both a collection resource (e.g., `bookstack://books`) that
+    returns the JSON-serialized list, and an individual-item resource (e.g., `bookstack://books/{id}`)
+    that returns the JSON-serialized detail object.
+14. All tool and resource methods MUST accept a `CancellationToken` and propagate it to every
+    `IBookStackApiClient` call.
+15. All log statements MUST use `ILogger<T>` structured logging with named placeholders; no
+    `Console.WriteLine` or string interpolation in log calls.
+
+### Non-Functional Requirements
+
+1. JSON serialization MUST use `System.Text.Json` with `JsonSerializerOptions` configured for
+   camelCase property naming and ISO 8601 date formatting, consistent with the API client layer.
+2. All tool and resource methods MUST complete within the `IBookStackApiClient` timeout window
+   (default 30 s); no additional per-tool timeout is introduced.
+3. No synchronous blocking calls (`.Result`, `.Wait()`, `Thread.Sleep`) are permitted in any tool
+   or resource method.
+4. Tool handler classes MUST remain stateless; all per-request state MUST be in method-local
+   variables.
+5. Each handler class MUST live in its own file under its respective subdirectory
+   (`tools/books/`, `tools/chapters/`, `tools/pages/`, `tools/shelves/`,
+   `resources/books/`, `resources/chapters/`, `resources/pages/`, `resources/shelves/`).
+
+---
+
+## Design
+
+### Component Diagram
+
+```mermaid
+graph TD
+    A[MCP Client<br/>LLM Agent / Claude Desktop] -->|tools/call| B[BookToolHandler\nChapterToolHandler\nPageToolHandler\nShelfToolHandler]
+    A -->|resources/read| C[BookResourceHandler\nChapterResourceHandler\nPageResourceHandler\nShelfResourceHandler]
+    B --> D[IBookStackApiClient]
+    C --> D
+    D -->|HTTP REST| E[BookStack Instance]
+    F[ILogger<T>] --> B
+    F --> C
+    G[JsonSerializerOptions<br/>camelCase / ISO 8601] --> B
+    G --> C
+```
+
+### Call Flow — Tool Invocation
+
+```mermaid
+sequenceDiagram
+    participant Client as MCP Client
+    participant Handler as XxxToolHandler
+    participant Client2 as IBookStackApiClient
+    participant BS as BookStack API
+
+    Client->>Handler: tools/call (name, arguments JSON)
+    Handler->>Handler: Validate arguments
+    alt Validation failure
+        Handler-->>Client: {"error":"validation_error","message":"…"}
+    end
+    Handler->>Client2: ListXxxAsync / GetXxxAsync / …
+    Client2->>BS: GET/POST/PUT/DELETE /api/…
+    alt 404 response
+        BS-->>Client2: 404 Not Found
+        Client2-->>Handler: HttpRequestException (404)
+        Handler-->>Client: {"error":"not_found","message":"…"}
+    end
+    alt 422 response
+        BS-->>Client2: 422 Unprocessable Entity
+        Client2-->>Handler: HttpRequestException (422)
+        Handler-->>Client: {"error":"validation_error","message":"…"}
+    end
+    BS-->>Client2: 200 OK (response body)
+    Client2-->>Handler: Typed model (Book, Chapter, etc.)
+    Handler->>Handler: JsonSerializer.Serialize(result, options)
+    Handler-->>Client: JSON string
+```
+
+### Tool Interface
+
+#### Books (6 tools)
+
+| Tool | Required Parameters | Optional Parameters | Returns |
+|---|---|---|---|
+| `bookstack_books_list` | — | `count: int`, `offset: int`, `sort: string` | JSON `ListResponse<Book>` |
+| `bookstack_books_read` | `id: int` | — | JSON `BookWithContents` |
+| `bookstack_books_create` | `name: string` | `description: string`, `description_html: string`, `tags: Tag[]`, `default_template_id: int` | JSON `Book` |
+| `bookstack_books_update` | `id: int` | `name: string`, `description: string`, `description_html: string`, `tags: Tag[]`, `default_template_id: int` | JSON `Book` |
+| `bookstack_books_delete` | `id: int` | — | JSON `{success, message}` |
+| `bookstack_books_export` | `id: int`, `format: string` | — | Export content string |
+
+#### Chapters (6 tools)
+
+| Tool | Required Parameters | Optional Parameters | Returns |
+|---|---|---|---|
+| `bookstack_chapters_list` | — | `count: int`, `offset: int`, `sort: string` | JSON `ListResponse<Chapter>` |
+| `bookstack_chapters_read` | `id: int` | — | JSON `ChapterWithPages` |
+| `bookstack_chapters_create` | `book_id: int`, `name: string` | `description: string`, `description_html: string`, `tags: Tag[]` | JSON `Chapter` |
+| `bookstack_chapters_update` | `id: int` | `book_id: int`, `name: string`, `description: string`, `description_html: string`, `tags: Tag[]` | JSON `Chapter` |
+| `bookstack_chapters_delete` | `id: int` | — | JSON `{success, message}` |
+| `bookstack_chapters_export` | `id: int`, `format: string` | — | Export content string |
+
+#### Pages (6 tools)
+
+| Tool | Required Parameters | Optional Parameters | Returns |
+|---|---|---|---|
+| `bookstack_pages_list` | — | `count: int`, `offset: int`, `sort: string` | JSON `ListResponse<Page>` |
+| `bookstack_pages_read` | `id: int` | — | JSON `PageWithContent` |
+| `bookstack_pages_create` | `name: string`, one of `book_id` or `chapter_id` | `html: string`, `markdown: string`, `tags: Tag[]` | JSON `Page` |
+| `bookstack_pages_update` | `id: int` | `name: string`, `book_id: int`, `chapter_id: int`, `html: string`, `markdown: string`, `tags: Tag[]` | JSON `Page` |
+| `bookstack_pages_delete` | `id: int` | — | JSON `{success, message}` |
+| `bookstack_pages_export` | `id: int`, `format: string` | — | Export content string |
+
+#### Shelves (5 tools)
+
+| Tool | Required Parameters | Optional Parameters | Returns |
+|---|---|---|---|
+| `bookstack_shelves_list` | — | `count: int`, `offset: int`, `sort: string` | JSON `ListResponse<Bookshelf>` |
+| `bookstack_shelves_read` | `id: int` | — | JSON `BookshelfWithBooks` |
+| `bookstack_shelves_create` | `name: string` | `description: string`, `description_html: string`, `tags: Tag[]`, `books: int[]` | JSON `Bookshelf` |
+| `bookstack_shelves_update` | `id: int` | `name: string`, `description: string`, `description_html: string`, `tags: Tag[]`, `books: int[]` | JSON `Bookshelf` |
+| `bookstack_shelves_delete` | `id: int` | — | JSON `{success, message}` |
+
+### Resource URI Contracts
+
+| Resource URI Template | Description | Returns |
+|---|---|---|
+| `bookstack://books` | All books visible to the authenticated user | JSON `ListResponse<Book>` |
+| `bookstack://books/{id}` | Single book including chapter and page hierarchy | JSON `BookWithContents` |
+| `bookstack://chapters` | All chapters visible to the authenticated user | JSON `ListResponse<Chapter>` |
+| `bookstack://chapters/{id}` | Single chapter including its pages list | JSON `ChapterWithPages` |
+| `bookstack://pages` | All pages visible to the authenticated user | JSON `ListResponse<Page>` |
+| `bookstack://pages/{id}` | Single page including HTML and Markdown content | JSON `PageWithContent` |
+| `bookstack://shelves` | All shelves visible to the authenticated user | JSON `ListResponse<Bookshelf>` |
+| `bookstack://shelves/{id}` | Single shelf including its assigned books list | JSON `BookshelfWithBooks` |
+
+### Parameter Detail — Tags
+
+All create and update tools that accept `tags` MUST document the parameter as:
+
+> Array of tag objects. Each object MUST have a `name` (string) and a `value` (string).
+> On update, providing this array replaces ALL existing tags. Omit to leave tags unchanged.
+
+The C# model is `IList<Tag>` where `Tag` is the existing `BookStack.Mcp.Server.Api.Models.Tag` type.
+The MCP SDK 1.2.0 binds complex parameters via `System.Text.Json`, so `IList<Tag>` can be used directly as
+a method parameter — no `tagsJson: string?` workaround is needed.
+
+### Parameter Detail — Export Formats
+
+The `format` parameter on all export tools MUST be one of: `html`, `pdf`, `plaintext`, `markdown`.
+This maps directly to the `ExportFormat` enum in `BookStack.Mcp.Server.Api.Models`.
+
+### Key Code Shapes
+
+```csharp
+// tools/books/BookToolHandler.cs — list with optional params, error handling
+[McpServerTool(Name = "bookstack_books_list")]
+[Description("List all books visible to the authenticated user with pagination options.")]
+public async Task<string> ListBooksAsync(
+    [Description("Number of books to return (1–500). Defaults to 20.")] int? count = null,
+    [Description("Number of books to skip for pagination. Defaults to 0.")] int? offset = null,
+    [Description("Sort field: name, created_at, updated_at. Defaults to name.")] string? sort = null,
+    CancellationToken ct = default)
+{
+    try
+    {
+        var query = (count.HasValue || offset.HasValue || sort is not null)
+            ? new ListQueryParams { Count = count, Offset = offset, Sort = sort }
+            : null;
+        var result = await _client.ListBooksAsync(query, ct);
+        return JsonSerializer.Serialize(result, _jsonOptions);
+    }
+    catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+    {
+        return JsonSerializer.Serialize(new { error = "not_found", message = ex.Message }, _jsonOptions);
+    }
+    catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.UnprocessableEntity)
+    {
+        return JsonSerializer.Serialize(new { error = "validation_error", message = ex.Message }, _jsonOptions);
+    }
+    catch (HttpRequestException ex)
+    {
+        _logger.LogError(ex, "BookStack API error listing books");
+        return JsonSerializer.Serialize(new { error = "api_error", message = ex.Message }, _jsonOptions);
+    }
+}
+```
+
+```csharp
+// tools/books/BookToolHandler.cs — create
+[McpServerTool(Name = "bookstack_books_create")]
+[Description("Create a new book. Books are the top-level containers in BookStack.")]
+public async Task<string> CreateBookAsync(
+    [Description("The book name (required, max 255 characters).")] string name,
+    [Description("Plain text description (max 1900 characters).")] string? description = null,
+    [Description("HTML description (max 2000 characters). Overrides description.")] string? descriptionHtml = null,
+    [Description("Tags to assign. Each tag must have a name and a value.")] IList<Tag>? tags = null,
+    [Description("ID of a page to use as the default template for new pages in this book.")] int? defaultTemplateId = null,
+    CancellationToken ct = default)
+{
+    // … construct CreateBookRequest, call _client.CreateBookAsync, serialize result
+}
+```
+
+```csharp
+// Shared JsonSerializerOptions — injected or constructed once per handler
+private static readonly JsonSerializerOptions _jsonOptions = new()
+{
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    WriteIndented = false,
+};
+```
+
+```csharp
+// resources/books/BookResourceHandler.cs — collection + individual item
+[McpServerResource(UriTemplate = "bookstack://books", Name = "Books")]
+[Description("All books visible to the authenticated user.")]
+public async Task<string> GetBooksAsync(CancellationToken ct)
+{
+    var result = await _client.ListBooksAsync(null, ct);
+    return JsonSerializer.Serialize(result, _jsonOptions);
+}
+
+[McpServerResource(UriTemplate = "bookstack://books/{id}", Name = "Book")]
+[Description("A single book including its chapter and page hierarchy.")]
+public async Task<string> GetBookAsync(
+    [Description("The book ID.")] int id,
+    CancellationToken ct)
+{
+    var result = await _client.GetBookAsync(id, ct);
+    return JsonSerializer.Serialize(result, _jsonOptions);
+}
+```
+
+> **Note**: The MCP SDK 1.2.0 binds tool arguments via `System.Text.Json`, so `IList<Tag>?` works
+> as a native parameter type. MCP clients pass tags as a JSON array: `[{"name":"env","value":"prod"}]`.
+> No `tagsJson: string?` workaround is needed.
+
+---
+
+## Acceptance Criteria
+
+### Books
+
+- [ ] Given a running server, when `bookstack_books_list` is called with no arguments, then it
+  returns a JSON string deserializable to `ListResponse<Book>` with `data` and `total` fields.
+- [ ] Given a running server, when `bookstack_books_list` is called with `count=5` and `offset=10`,
+  then the API client receives `ListQueryParams { Count = 5, Offset = 10 }`.
+- [ ] Given a valid book ID, when `bookstack_books_read` is called, then it returns a JSON string
+  deserializable to `BookWithContents` containing a `contents` array.
+- [ ] Given a non-existent book ID, when `bookstack_books_read` is called, then it returns a JSON
+  string with `"error": "not_found"` and does not throw an exception.
+- [ ] Given a valid `name`, when `bookstack_books_create` is called, then it returns a JSON string
+  deserializable to `Book` with a non-zero `id` field.
+- [ ] Given an existing book ID, when `bookstack_books_update` is called with a new `name`, then it
+  returns a JSON string with the updated name.
+- [ ] Given an existing book ID, when `bookstack_books_delete` is called, then it returns
+  `{"success":true,"message":"Book <id> deleted successfully"}`.
+- [ ] Given an existing book ID and `format=markdown`, when `bookstack_books_export` is called, then
+  it returns the raw Markdown export string from the BookStack API.
+- [ ] Given `format=invalid`, when `bookstack_books_export` is called, then it returns a JSON string
+  with `"error": "validation_error"`.
+- [ ] When `bookstack://books` resource is read, then it returns JSON deserializable to
+  `ListResponse<Book>`.
+- [ ] When `bookstack://books/{id}` resource is read with a valid ID, then it returns JSON
+  deserializable to `BookWithContents`.
+
+### Chapters
+
+- [ ] Given a valid `book_id` and `name`, when `bookstack_chapters_create` is called, then it
+  returns a JSON string deserializable to `Chapter` containing the correct `book_id`.
+- [ ] Given a non-existent chapter ID, when `bookstack_chapters_read` is called, then it returns
+  `{"error":"not_found","message":"…"}`.
+- [ ] Given `bookstack_chapters_update` called with a `book_id`, then the chapter is moved to the
+  specified book (API proxied correctly).
+- [ ] Given an existing chapter ID, when `bookstack_chapters_delete` is called, then it returns
+  `{"success":true,"message":"Chapter <id> deleted successfully"}`.
+- [ ] Given `format=pdf`, when `bookstack_chapters_export` is called, then it returns the raw export
+  string from the API.
+- [ ] When `bookstack://chapters/{id}` resource is read, then it returns JSON deserializable to
+  `ChapterWithPages` containing a `pages` array.
+
+### Pages
+
+- [ ] Given `name` and `book_id`, when `bookstack_pages_create` is called, then it returns JSON
+  deserializable to `Page`.
+- [ ] Given `name` with neither `book_id` nor `chapter_id`, when `bookstack_pages_create` is called,
+  then it returns `{"error":"validation_error","message":"Either book_id or chapter_id is required"}`.
+- [ ] Given `name` with both `book_id` and `chapter_id` provided, then `bookstack_pages_create`
+  passes both to `CreatePageRequest` without error (BookStack API resolves parent precedence).
+- [ ] Given `markdown` content, when `bookstack_pages_create` is called, then `CreatePageRequest.Markdown`
+  is populated and `Html` is null.
+- [ ] Given an existing page ID, when `bookstack_pages_read` is called, then the returned JSON is
+  deserializable to `PageWithContent` containing non-empty `html` and optionally `markdown` fields.
+- [ ] Given a non-existent page ID, when `bookstack_pages_delete` is called, then it returns
+  `{"error":"not_found","message":"…"}`.
+- [ ] When `bookstack://pages/{id}` resource is read, then it returns JSON deserializable to
+  `PageWithContent`.
+
+### Shelves
+
+- [ ] Given a valid `name`, when `bookstack_shelves_create` is called, then it returns JSON
+  deserializable to `Bookshelf`.
+- [ ] Given `books=[1,2,3]`, when `bookstack_shelves_create` is called, then `CreateShelfRequest.Books`
+  is `[1, 2, 3]`.
+- [ ] Given an existing shelf ID and `books=[5]`, when `bookstack_shelves_update` is called, then
+  `UpdateShelfRequest.Books` is `[5]` (replaces all existing books on the shelf).
+- [ ] Given a non-existent shelf ID, when `bookstack_shelves_read` is called, then it returns
+  `{"error":"not_found","message":"…"}`.
+- [ ] Given an existing shelf ID, when `bookstack_shelves_delete` is called, then it returns
+  `{"success":true,"message":"Shelf <id> deleted successfully"}` and the shelf's assigned books are
+  NOT deleted.
+- [ ] When `bookstack://shelves/{id}` resource is read, then it returns JSON deserializable to
+  `BookshelfWithBooks` containing a `books` array.
+
+### Cross-Cutting
+
+- [ ] Given a network timeout, any tool call returns `{"error":"api_error","message":"…"}` and logs
+  the exception at `Error` level.
+- [ ] All 23 tools are returned in `tools/list` with accurate names and non-empty descriptions.
+- [ ] All 8 resources are returned in `resources/list` with correct URI templates.
+- [ ] No tool or resource method writes to `Console.Out` or `Console.Error`.
+
+---
+
+## Security Considerations
+
+- All tool parameters originate from MCP clients and MUST be treated as untrusted input. Integer IDs
+  MUST be validated as positive integers before use. String parameters such as `name`, `description`,
+  and `markdown` content are passed directly to the BookStack API, which enforces its own length and
+  content limits; the tool layer MUST NOT perform HTML escaping of content fields.
+- The `tags` parameter is bound by the SDK as `IList<Tag>?`; malformed JSON from the MCP client
+  will result in a protocol-level binding error before the handler is invoked.
+- API credentials (`BOOKSTACK_TOKEN_ID`, `BOOKSTACK_TOKEN_SECRET`) are handled entirely by
+  `IBookStackApiClient` (FEAT-0018) and MUST NOT be logged or echoed in tool responses.
+- Export tool responses may contain arbitrary HTML content from BookStack. MCP clients that render
+  the output are responsible for their own escaping; the tool layer MUST NOT strip or sanitize export
+  content.
+- Delete operations are irreversible at the tool level (BookStack moves content to the recycle bin;
+  permanent deletion is a separate operation). No confirmation handshake is required because MCP
+  callers are assumed to be LLM agents that have already obtained user intent.
+
+---
+
+## Test Cases
+
+The following test cases MUST be implemented in `tests/BookStack.Mcp.Server.Tests/` using TUnit,
+Moq, and FluentAssertions. Each test MUST mock `IBookStackApiClient` to avoid real HTTP calls.
+
+### Books
+
+1. `ListBooksAsync_NoParams_CallsClientWithNullQuery` — verifies `ListBooksAsync(null, ct)` is called.
+2. `ListBooksAsync_WithCountAndOffset_PassesParams` — verifies `ListQueryParams` is populated correctly.
+3. `ReadBookAsync_ValidId_ReturnsSerializedBook` — verifies JSON output is deserializable to `BookWithContents`.
+4. `ReadBookAsync_NotFound_ReturnsErrorJson` — mocks `HttpRequestException(HttpStatusCode.NotFound)`.
+5. `CreateBookAsync_ValidName_ReturnsSerializedBook` — verifies `CreateBookRequest.Name` is set.
+6. `CreateBookAsync_WithTags_PassesTagsToRequest` — verifies `CreateBookRequest.Tags` is populated correctly.
+7. `UpdateBookAsync_ValidId_ReturnsUpdatedBook`.
+8. `DeleteBookAsync_ValidId_ReturnsSuccessJson`.
+9. `ExportBookAsync_InvalidFormat_ReturnsValidationError`.
+10. `ExportBookAsync_ValidFormatMarkdown_ReturnsExportString`.
+
+### Chapters
+
+11. `CreateChapterAsync_ValidBookIdAndName_ReturnsSerializedChapter`.
+12. `ReadChapterAsync_NotFound_ReturnsErrorJson`.
+13. `DeleteChapterAsync_ValidId_ReturnsSuccessJson`.
+
+### Pages
+
+14. `CreatePageAsync_NoParentId_ReturnsValidationError`.
+15. `CreatePageAsync_WithBookId_CallsClientWithCorrectRequest`.
+16. `CreatePageAsync_WithMarkdown_SetsMarkdownField`.
+17. `ReadPageAsync_ValidId_ReturnsPageWithContent`.
+18. `DeletePageAsync_NotFound_ReturnsErrorJson`.
+
+### Shelves
+
+19. `CreateShelfAsync_WithBooks_SetsBooksList`.
+20. `UpdateShelfAsync_WithBooks_ReplacesExistingBooks`.
+21. `DeleteShelfAsync_ValidId_ReturnsSuccessJson`.
+
+### Resources
+
+22. `GetBooksResource_ReturnsSerializedListResponse`.
+23. `GetBookByIdResource_ValidId_ReturnsSerializedBookWithContents`.
+24. `GetPagesResource_ReturnsSerializedListResponse`.
+25. `GetPageByIdResource_ValidId_ReturnsSerializedPageWithContent`.
+
+---
+
+## Open Questions
+
+- [ ] Should the `bookstack://books` resource apply pagination defaults (count=20) or return all
+  books in one response? The current decision is to pass `null` to `ListBooksAsync`, accepting
+  whatever the BookStack API default is. Revisit if large instances cause timeout issues.
+- [ ] Should export tools for `pdf` format return the raw byte content encoded as base64 within the
+  JSON string, or a metadata envelope? Current decision: return the raw string as returned by
+  `IBookStackApiClient.ExportBookAsync`, consistent with the TypeScript reference. Revisit for binary
+  format completeness.
+
+---
+
+## Out of Scope
+
+- Cover image assignment (`image_id` parameter) on book and shelf create/update — deferred until
+  an `images` tool implementation is available.
+- Content permissions management on individual books, chapters, pages, and shelves — covered by a
+  separate permissions feature.
+- Page revision history retrieval — not exposed by the current `IBookStackApiClient`.
+- Draft pages — the API accepts draft state but this spec does not add a `draft` parameter to
+  `bookstack_pages_create`; adding it is a minor enhancement that can be done in the same PR.

--- a/docs/features/content-tools/tasks.md
+++ b/docs/features/content-tools/tasks.md
@@ -1,0 +1,70 @@
+# Task Decomposition: Content Tools and Resources — Books, Chapters, Pages, Shelves
+
+**Feature**: FEAT-0007
+**Parent Issue**: [#7](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/7)
+**Decomposed**: 2026-04-20
+**Status**: Tasks created on GitHub Issues
+
+---
+
+## Task List
+
+Tasks are ordered by dependency. Each task is independently committable.
+
+### Phase 1 — Tool Handler Implementations
+
+- [ ] [Task 1] Implement `BookToolHandler` — 6 CRUD tools (`list`, `read`, `create`, `update`, `delete`, `export`) → [#45](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/45)
+  - Establishes `_jsonOptions`, error-handling, and validation patterns for Tasks 2–5
+- [ ] [P] [Task 2] Implement `ChapterToolHandler` — 6 CRUD tools (`list`, `read`, `create`, `update`, `delete`, `export`) → [#43](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/43)
+  - Depends on: #45 (follow patterns established in Task 1)
+- [ ] [P] [Task 3] Implement `PageToolHandler` — 6 CRUD tools (`list`, `read`, `create`, `update`, `delete`, `export`) → [#44](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/44)
+  - Depends on: #45 (follow patterns established in Task 1)
+- [ ] [P] [Task 4] Implement `ShelfToolHandler` — 5 CRUD tools (`list`, `read`, `create`, `update`, `delete`) → [#46](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/46)
+  - Depends on: #45 (follow patterns established in Task 1)
+
+### Phase 2 — Resource Handler Implementations
+
+- [ ] [Task 5] Implement resource handlers — `BookResourceHandler`, `ChapterResourceHandler`, `PageResourceHandler`, `ShelfResourceHandler` (collection + `{id}` methods) → [#49](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/49)
+  - Depends on: #45, #43, #44, #46
+
+### Phase 3 — Tests
+
+- [ ] [Task 6] Tests — `BookToolHandlerTests` (10 test cases) → [#47](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/47)
+  - Depends on: #45
+- [ ] [P] [Task 7] Tests — `ChapterToolHandlerTests`, `PageToolHandlerTests`, `ShelfToolHandlerTests` (11 test cases) → [#50](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/50)
+  - Depends on: #43, #44, #46, #47 (follow test setup pattern from Task 6)
+- [ ] [P] [Task 8] Tests — `BookResourceHandlerTests`, `PageResourceHandlerTests` (4 test cases) → [#48](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/48)
+  - Depends on: #49, #47 (follow test setup pattern from Task 6)
+
+---
+
+## Dependency Graph
+
+```
+#45 (BookToolHandler)
+     ├─► #43 (ChapterToolHandler)
+     ├─► #44 (PageToolHandler)
+     └─► #46 (ShelfToolHandler)
+               └─► #49 (resource handlers)
+#45 ──────────────► #47 (BookToolHandler tests)
+#43, #44, #46 ─────► #50 (Chapter/Page/Shelf tests)
+#49 ──────────────► #48 (resource handler tests)
+#47 ──────────────► #50, #48 (test setup pattern)
+```
+
+---
+
+## Summary
+
+| Issue | Title | Plan Task | Tests |
+| --- | --- | --- | --- |
+| [#45](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/45) | Implement `BookToolHandler` — 6 CRUD tools | Task 1 | #47 |
+| [#43](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/43) | Implement `ChapterToolHandler` — 6 CRUD tools | Task 2 | #50 |
+| [#44](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/44) | Implement `PageToolHandler` — 6 CRUD tools | Task 3 | #50 |
+| [#46](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/46) | Implement `ShelfToolHandler` — 5 CRUD tools | Task 4 | #50 |
+| [#49](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/49) | Implement resource handlers (4 handlers, 8 methods) | Task 5 | #48 |
+| [#47](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/47) | Tests — `BookToolHandler` (10 test cases) | Task 6 | — |
+| [#50](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/50) | Tests — `ChapterToolHandler`, `PageToolHandler`, `ShelfToolHandler` (11 test cases) | Task 7 | — |
+| [#48](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/48) | Tests — resource handlers `BookResourceHandler`, `PageResourceHandler` (4 test cases) | Task 8 | — |
+
+**Total sub-issues**: 8 | **Total test cases**: 25 | **Missing ADRs**: None

--- a/src/BookStack.Mcp.Server/resources/books/BookResourceHandler.cs
+++ b/src/BookStack.Mcp.Server/resources/books/BookResourceHandler.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text.Json;
 using BookStack.Mcp.Server.Api;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -12,8 +13,47 @@ internal sealed class BookResourceHandler(
     private readonly IBookStackApiClient _client = client;
     private readonly ILogger<BookResourceHandler> _logger = logger;
 
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
+
     [McpServerResource(UriTemplate = "bookstack://books", Name = "Books")]
-    [Description("All books in the BookStack instance")]
-    public Task<string> GetBooksAsync(CancellationToken ct)
-        => throw new NotImplementedException("Implemented in a future issue");
+    [Description("All books visible to the authenticated user.")]
+    public async Task<string> GetBooksAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var result = await _client.ListBooksAsync(null, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error listing books resource: {Message}", ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
+
+    [McpServerResource(UriTemplate = "bookstack://books/{id}", Name = "Book")]
+    [Description("A single book including its chapter and page hierarchy.")]
+    public async Task<string> GetBookAsync(
+        [Description("The book ID.")] int id,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var result = await _client.GetBookAsync(id, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error reading book resource {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 }

--- a/src/BookStack.Mcp.Server/resources/chapters/ChapterResourceHandler.cs
+++ b/src/BookStack.Mcp.Server/resources/chapters/ChapterResourceHandler.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text.Json;
 using BookStack.Mcp.Server.Api;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -12,8 +13,47 @@ internal sealed class ChapterResourceHandler(
     private readonly IBookStackApiClient _client = client;
     private readonly ILogger<ChapterResourceHandler> _logger = logger;
 
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
+
     [McpServerResource(UriTemplate = "bookstack://chapters", Name = "Chapters")]
-    [Description("All chapters in the BookStack instance")]
-    public Task<string> GetChaptersAsync(CancellationToken ct)
-        => throw new NotImplementedException("Implemented in a future issue");
+    [Description("All chapters visible to the authenticated user.")]
+    public async Task<string> GetChaptersAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var result = await _client.ListChaptersAsync(null, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error listing chapters resource: {Message}", ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
+
+    [McpServerResource(UriTemplate = "bookstack://chapters/{id}", Name = "Chapter")]
+    [Description("A single chapter including its list of pages.")]
+    public async Task<string> GetChapterAsync(
+        [Description("The chapter ID.")] int id,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var result = await _client.GetChapterAsync(id, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error reading chapter resource {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 }

--- a/src/BookStack.Mcp.Server/resources/pages/PageResourceHandler.cs
+++ b/src/BookStack.Mcp.Server/resources/pages/PageResourceHandler.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text.Json;
 using BookStack.Mcp.Server.Api;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -12,8 +13,47 @@ internal sealed class PageResourceHandler(
     private readonly IBookStackApiClient _client = client;
     private readonly ILogger<PageResourceHandler> _logger = logger;
 
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
+
     [McpServerResource(UriTemplate = "bookstack://pages", Name = "Pages")]
-    [Description("All pages in the BookStack instance")]
-    public Task<string> GetPagesAsync(CancellationToken ct)
-        => throw new NotImplementedException("Implemented in a future issue");
+    [Description("All pages visible to the authenticated user.")]
+    public async Task<string> GetPagesAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var result = await _client.ListPagesAsync(null, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error listing pages resource: {Message}", ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
+
+    [McpServerResource(UriTemplate = "bookstack://pages/{id}", Name = "Page")]
+    [Description("A single page including its HTML and Markdown content.")]
+    public async Task<string> GetPageAsync(
+        [Description("The page ID.")] int id,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var result = await _client.GetPageAsync(id, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error reading page resource {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 }

--- a/src/BookStack.Mcp.Server/resources/shelves/ShelfResourceHandler.cs
+++ b/src/BookStack.Mcp.Server/resources/shelves/ShelfResourceHandler.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text.Json;
 using BookStack.Mcp.Server.Api;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -12,8 +13,47 @@ internal sealed class ShelfResourceHandler(
     private readonly IBookStackApiClient _client = client;
     private readonly ILogger<ShelfResourceHandler> _logger = logger;
 
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
+
     [McpServerResource(UriTemplate = "bookstack://shelves", Name = "Shelves")]
-    [Description("All shelves in the BookStack instance")]
-    public Task<string> GetShelvesAsync(CancellationToken ct)
-        => throw new NotImplementedException("Implemented in a future issue");
+    [Description("All bookshelves visible to the authenticated user.")]
+    public async Task<string> GetShelvesAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var result = await _client.ListShelvesAsync(null, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error listing shelves resource: {Message}", ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
+
+    [McpServerResource(UriTemplate = "bookstack://shelves/{id}", Name = "Shelf")]
+    [Description("A single bookshelf including its list of assigned books.")]
+    public async Task<string> GetShelfAsync(
+        [Description("The shelf ID.")] int id,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var result = await _client.GetShelfAsync(id, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error reading shelf resource {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 }

--- a/src/BookStack.Mcp.Server/tools/books/BookToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/books/BookToolHandler.cs
@@ -1,5 +1,8 @@
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Text.Json;
 using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 
@@ -11,34 +14,206 @@ internal sealed class BookToolHandler(IBookStackApiClient client, ILogger<BookTo
     private readonly IBookStackApiClient _client = client;
     private readonly ILogger<BookToolHandler> _logger = logger;
 
-    [McpServerTool(Name = "bookstack_books_list"), Description("List all books in BookStack")]
-    public Task<string> ListBooksAsync(CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #7");
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
 
-    [McpServerTool(Name = "bookstack_books_read"), Description("Get a book by ID")]
-    public Task<string> ReadBookAsync(
-        [Description("The book ID")] int id, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #7");
+    [McpServerTool(Name = "bookstack_books_list")]
+    [Description("List all books visible to the authenticated user with pagination options. Books are the top-level containers in the BookStack content hierarchy.")]
+    public async Task<string> ListBooksAsync(
+        [Description("Number of books to return (1–500). Defaults to 20.")] int? count = null,
+        [Description("Number of books to skip for pagination. Defaults to 0.")] int? offset = null,
+        [Description("Sort field: name, created_at, updated_at. Defaults to name.")] string? sort = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var query = (count.HasValue || offset.HasValue || sort is not null)
+                ? new ListQueryParams { Count = count, Offset = offset, Sort = sort }
+                : null;
+            var result = await _client.ListBooksAsync(query, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 422)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error listing books: {Message}", ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 
-    [McpServerTool(Name = "bookstack_books_create"), Description("Create a new book")]
-    public Task<string> CreateBookAsync(
-        [Description("The book name")] string name, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #7");
+    [McpServerTool(Name = "bookstack_books_read")]
+    [Description("Get a single book by ID, including its full chapter and page hierarchy.")]
+    public async Task<string> ReadBookAsync(
+        [Description("The book ID. Must be a positive integer.")] int id,
+        CancellationToken ct = default)
+    {
+        if (id <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+        }
 
-    [McpServerTool(Name = "bookstack_books_update"), Description("Update an existing book")]
-    public Task<string> UpdateBookAsync(
-        [Description("The book ID")] int id, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #7");
+        try
+        {
+            var result = await _client.GetBookAsync(id, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error reading book {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 
-    [McpServerTool(Name = "bookstack_books_delete"), Description("Delete a book by ID")]
-    public Task<string> DeleteBookAsync(
-        [Description("The book ID")] int id, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #7");
+    [McpServerTool(Name = "bookstack_books_create")]
+    [Description("Create a new book. Books are the top-level containers for chapters and pages in BookStack.")]
+    public async Task<string> CreateBookAsync(
+        [Description("The book name (required, max 255 characters).")] string name,
+        [Description("Plain text description (max 1900 characters).")] string? description = null,
+        [Description("HTML description (max 2000 characters). Overrides description if both provided.")] string? descriptionHtml = null,
+        [Description("Tags to assign. Each object must have name and value string properties. On update, providing this array replaces ALL existing tags.")] IList<Tag>? tags = null,
+        [Description("ID of a page to use as the default template for new pages in this book.")] int? defaultTemplateId = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var request = new CreateBookRequest
+            {
+                Name = name,
+                Description = description,
+                DescriptionHtml = descriptionHtml,
+                Tags = tags,
+                DefaultTemplateId = defaultTemplateId,
+            };
+            var result = await _client.CreateBookAsync(request, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 422)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error creating book: {Message}", ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 
-    [McpServerTool(Name = "bookstack_books_export"), Description("Export a book in a given format")]
-    public Task<string> ExportBookAsync(
-        [Description("The book ID")] int id,
-        [Description("Export format: html, pdf, plaintext, markdown")] string format,
-        CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #7");
+    [McpServerTool(Name = "bookstack_books_update")]
+    [Description("Update an existing book's name, description, or tags.")]
+    public async Task<string> UpdateBookAsync(
+        [Description("The book ID. Must be a positive integer.")] int id,
+        [Description("New name for the book (max 255 characters).")] string? name = null,
+        [Description("Plain text description (max 1900 characters).")] string? description = null,
+        [Description("HTML description (max 2000 characters). Overrides description if both provided.")] string? descriptionHtml = null,
+        [Description("Tags to assign. Providing this array replaces ALL existing tags. Omit to leave tags unchanged.")] IList<Tag>? tags = null,
+        [Description("ID of a page to use as the default template for new pages in this book.")] int? defaultTemplateId = null,
+        CancellationToken ct = default)
+    {
+        if (id <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+        }
+
+        try
+        {
+            var request = new UpdateBookRequest
+            {
+                Name = name,
+                Description = description,
+                DescriptionHtml = descriptionHtml,
+                Tags = tags,
+                DefaultTemplateId = defaultTemplateId,
+            };
+            var result = await _client.UpdateBookAsync(id, request, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 422)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error updating book {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
+
+    [McpServerTool(Name = "bookstack_books_delete")]
+    [Description("Delete a book by ID. This moves the book and all its contents to the recycle bin.")]
+    public async Task<string> DeleteBookAsync(
+        [Description("The book ID. Must be a positive integer.")] int id,
+        CancellationToken ct = default)
+    {
+        if (id <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+        }
+
+        try
+        {
+            await _client.DeleteBookAsync(id, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(new { success = true, message = $"Book {id} deleted successfully" }, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error deleting book {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
+
+    [McpServerTool(Name = "bookstack_books_export")]
+    [Description("Export a book in the specified format. Returns the raw export content as a string.")]
+    public async Task<string> ExportBookAsync(
+        [Description("The book ID. Must be a positive integer.")] int id,
+        [Description("Export format. Must be one of: html, pdf, plaintext, markdown.")] string format,
+        CancellationToken ct = default)
+    {
+        if (id <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+        }
+
+        if (!Enum.TryParse<ExportFormat>(format, ignoreCase: true, out var exportFormat))
+        {
+            return JsonSerializer.Serialize(
+                new { error = "validation_error", message = $"Invalid export format '{format}'. Must be one of: html, pdf, plaintext, markdown." },
+                _jsonOptions);
+        }
+
+        try
+        {
+            return await _client.ExportBookAsync(id, exportFormat, ct).ConfigureAwait(false);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error exporting book {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 }

--- a/src/BookStack.Mcp.Server/tools/chapters/ChapterToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/chapters/ChapterToolHandler.cs
@@ -1,5 +1,8 @@
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Text.Json;
 using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 
@@ -11,34 +14,212 @@ internal sealed class ChapterToolHandler(IBookStackApiClient client, ILogger<Cha
     private readonly IBookStackApiClient _client = client;
     private readonly ILogger<ChapterToolHandler> _logger = logger;
 
-    [McpServerTool(Name = "bookstack_chapters_list"), Description("List all chapters in BookStack")]
-    public Task<string> ListChaptersAsync(CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
 
-    [McpServerTool(Name = "bookstack_chapters_read"), Description("Get a chapter by ID")]
-    public Task<string> ReadChapterAsync(
-        [Description("The chapter ID")] int id, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+    [McpServerTool(Name = "bookstack_chapters_list")]
+    [Description("List all chapters visible to the authenticated user with pagination options.")]
+    public async Task<string> ListChaptersAsync(
+        [Description("Number of chapters to return (1–500). Defaults to 20.")] int? count = null,
+        [Description("Number of chapters to skip for pagination. Defaults to 0.")] int? offset = null,
+        [Description("Sort field: name, created_at, updated_at. Defaults to name.")] string? sort = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var query = (count.HasValue || offset.HasValue || sort is not null)
+                ? new ListQueryParams { Count = count, Offset = offset, Sort = sort }
+                : null;
+            var result = await _client.ListChaptersAsync(query, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 422)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error listing chapters: {Message}", ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 
-    [McpServerTool(Name = "bookstack_chapters_create"), Description("Create a new chapter")]
-    public Task<string> CreateChapterAsync(
-        [Description("The chapter name")] string name, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+    [McpServerTool(Name = "bookstack_chapters_read")]
+    [Description("Get a single chapter by ID, including its list of pages.")]
+    public async Task<string> ReadChapterAsync(
+        [Description("The chapter ID. Must be a positive integer.")] int id,
+        CancellationToken ct = default)
+    {
+        if (id <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+        }
 
-    [McpServerTool(Name = "bookstack_chapters_update"), Description("Update an existing chapter")]
-    public Task<string> UpdateChapterAsync(
-        [Description("The chapter ID")] int id, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+        try
+        {
+            var result = await _client.GetChapterAsync(id, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error reading chapter {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 
-    [McpServerTool(Name = "bookstack_chapters_delete"), Description("Delete a chapter by ID")]
-    public Task<string> DeleteChapterAsync(
-        [Description("The chapter ID")] int id, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+    [McpServerTool(Name = "bookstack_chapters_create")]
+    [Description("Create a new chapter inside a book.")]
+    public async Task<string> CreateChapterAsync(
+        [Description("ID of the book that will contain this chapter. Must be a positive integer.")] int bookId,
+        [Description("The chapter name (required, max 255 characters).")] string name,
+        [Description("Plain text description (max 1900 characters).")] string? description = null,
+        [Description("HTML description (max 2000 characters). Overrides description if both provided.")] string? descriptionHtml = null,
+        [Description("Tags to assign. Each object must have name and value string properties.")] IList<Tag>? tags = null,
+        CancellationToken ct = default)
+    {
+        if (bookId <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"bookId must be a positive integer, got {bookId}." }, _jsonOptions);
+        }
 
-    [McpServerTool(Name = "bookstack_chapters_export"), Description("Export a chapter in a given format")]
-    public Task<string> ExportChapterAsync(
-        [Description("The chapter ID")] int id,
-        [Description("Export format: html, pdf, plaintext, markdown")] string format,
-        CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+        try
+        {
+            var request = new CreateChapterRequest
+            {
+                BookId = bookId,
+                Name = name,
+                Description = description,
+                DescriptionHtml = descriptionHtml,
+                Tags = tags,
+            };
+            var result = await _client.CreateChapterAsync(request, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 422)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error creating chapter: {Message}", ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
+
+    [McpServerTool(Name = "bookstack_chapters_update")]
+    [Description("Update an existing chapter's name, description, tags, or move it to a different book.")]
+    public async Task<string> UpdateChapterAsync(
+        [Description("The chapter ID. Must be a positive integer.")] int id,
+        [Description("Move the chapter to a different book by specifying the target book ID.")] int? bookId = null,
+        [Description("New name for the chapter (max 255 characters).")] string? name = null,
+        [Description("Plain text description (max 1900 characters).")] string? description = null,
+        [Description("HTML description (max 2000 characters). Overrides description if both provided.")] string? descriptionHtml = null,
+        [Description("Tags to assign. Providing this array replaces ALL existing tags. Omit to leave tags unchanged.")] IList<Tag>? tags = null,
+        CancellationToken ct = default)
+    {
+        if (id <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+        }
+
+        if (bookId.HasValue && bookId.Value <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"bookId must be a positive integer, got {bookId}." }, _jsonOptions);
+        }
+
+        try
+        {
+            var request = new UpdateChapterRequest
+            {
+                BookId = bookId,
+                Name = name,
+                Description = description,
+                DescriptionHtml = descriptionHtml,
+                Tags = tags,
+            };
+            var result = await _client.UpdateChapterAsync(id, request, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 422)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error updating chapter {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
+
+    [McpServerTool(Name = "bookstack_chapters_delete")]
+    [Description("Delete a chapter by ID. This moves the chapter and all its pages to the recycle bin.")]
+    public async Task<string> DeleteChapterAsync(
+        [Description("The chapter ID. Must be a positive integer.")] int id,
+        CancellationToken ct = default)
+    {
+        if (id <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+        }
+
+        try
+        {
+            await _client.DeleteChapterAsync(id, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(new { success = true, message = $"Chapter {id} deleted successfully" }, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error deleting chapter {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
+
+    [McpServerTool(Name = "bookstack_chapters_export")]
+    [Description("Export a chapter in the specified format. Returns the raw export content as a string.")]
+    public async Task<string> ExportChapterAsync(
+        [Description("The chapter ID. Must be a positive integer.")] int id,
+        [Description("Export format. Must be one of: html, pdf, plaintext, markdown.")] string format,
+        CancellationToken ct = default)
+    {
+        if (id <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+        }
+
+        if (!Enum.TryParse<ExportFormat>(format, ignoreCase: true, out var exportFormat))
+        {
+            return JsonSerializer.Serialize(
+                new { error = "validation_error", message = $"Invalid export format '{format}'. Must be one of: html, pdf, plaintext, markdown." },
+                _jsonOptions);
+        }
+
+        try
+        {
+            return await _client.ExportChapterAsync(id, exportFormat, ct).ConfigureAwait(false);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error exporting chapter {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 }

--- a/src/BookStack.Mcp.Server/tools/pages/PageToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/pages/PageToolHandler.cs
@@ -1,5 +1,8 @@
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Text.Json;
 using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 
@@ -11,34 +14,212 @@ internal sealed class PageToolHandler(IBookStackApiClient client, ILogger<PageTo
     private readonly IBookStackApiClient _client = client;
     private readonly ILogger<PageToolHandler> _logger = logger;
 
-    [McpServerTool(Name = "bookstack_pages_list"), Description("List all pages in BookStack")]
-    public Task<string> ListPagesAsync(CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
 
-    [McpServerTool(Name = "bookstack_pages_read"), Description("Get a page by ID")]
-    public Task<string> ReadPageAsync(
-        [Description("The page ID")] int id, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+    [McpServerTool(Name = "bookstack_pages_list")]
+    [Description("List all pages visible to the authenticated user with pagination options.")]
+    public async Task<string> ListPagesAsync(
+        [Description("Number of pages to return (1–500). Defaults to 20.")] int? count = null,
+        [Description("Number of pages to skip for pagination. Defaults to 0.")] int? offset = null,
+        [Description("Sort field: name, created_at, updated_at. Defaults to name.")] string? sort = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var query = (count.HasValue || offset.HasValue || sort is not null)
+                ? new ListQueryParams { Count = count, Offset = offset, Sort = sort }
+                : null;
+            var result = await _client.ListPagesAsync(query, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 422)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error listing pages: {Message}", ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 
-    [McpServerTool(Name = "bookstack_pages_create"), Description("Create a new page")]
-    public Task<string> CreatePageAsync(
-        [Description("The page name")] string name, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+    [McpServerTool(Name = "bookstack_pages_read")]
+    [Description("Get a single page by ID, including its HTML and Markdown content.")]
+    public async Task<string> ReadPageAsync(
+        [Description("The page ID. Must be a positive integer.")] int id,
+        CancellationToken ct = default)
+    {
+        if (id <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+        }
 
-    [McpServerTool(Name = "bookstack_pages_update"), Description("Update an existing page")]
-    public Task<string> UpdatePageAsync(
-        [Description("The page ID")] int id, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+        try
+        {
+            var result = await _client.GetPageAsync(id, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error reading page {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 
-    [McpServerTool(Name = "bookstack_pages_delete"), Description("Delete a page by ID")]
-    public Task<string> DeletePageAsync(
-        [Description("The page ID")] int id, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+    [McpServerTool(Name = "bookstack_pages_create")]
+    [Description("Create a new page. Either bookId or chapterId must be provided to specify where the page is created.")]
+    public async Task<string> CreatePageAsync(
+        [Description("The page name (required, max 255 characters).")] string name,
+        [Description("ID of the book to create the page in. Required if chapterId is not provided.")] int? bookId = null,
+        [Description("ID of the chapter to create the page in. Required if bookId is not provided.")] int? chapterId = null,
+        [Description("HTML content for the page.")] string? html = null,
+        [Description("Markdown content for the page. If both html and markdown are provided, html takes precedence.")] string? markdown = null,
+        [Description("Tags to assign. Each object must have name and value string properties.")] IList<Tag>? tags = null,
+        CancellationToken ct = default)
+    {
+        if (bookId is null && chapterId is null)
+        {
+            return JsonSerializer.Serialize(
+                new { error = "validation_error", message = "Either bookId or chapterId is required." },
+                _jsonOptions);
+        }
+        try
+        {
+            var request = new CreatePageRequest
+            {
+                Name = name,
+                BookId = bookId,
+                ChapterId = chapterId,
+                Html = html,
+                Markdown = markdown,
+                Tags = tags,
+            };
+            var result = await _client.CreatePageAsync(request, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 422)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error creating page: {Message}", ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 
-    [McpServerTool(Name = "bookstack_pages_export"), Description("Export a page in a given format")]
-    public Task<string> ExportPageAsync(
-        [Description("The page ID")] int id,
-        [Description("Export format: html, pdf, plaintext, markdown")] string format,
-        CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+    [McpServerTool(Name = "bookstack_pages_update")]
+    [Description("Update an existing page's name, content, tags, or move it to a different book or chapter.")]
+    public async Task<string> UpdatePageAsync(
+        [Description("The page ID. Must be a positive integer.")] int id,
+        [Description("New name for the page (max 255 characters).")] string? name = null,
+        [Description("Move the page to a different book.")] int? bookId = null,
+        [Description("Move the page to a different chapter.")] int? chapterId = null,
+        [Description("HTML content for the page.")] string? html = null,
+        [Description("Markdown content for the page.")] string? markdown = null,
+        [Description("Tags to assign. Providing this array replaces ALL existing tags. Omit to leave tags unchanged.")] IList<Tag>? tags = null,
+        CancellationToken ct = default)
+    {
+        if (id <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+        }
+
+        try
+        {
+            var request = new UpdatePageRequest
+            {
+                Name = name,
+                BookId = bookId,
+                ChapterId = chapterId,
+                Html = html,
+                Markdown = markdown,
+                Tags = tags,
+            };
+            var result = await _client.UpdatePageAsync(id, request, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 422)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error updating page {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
+
+    [McpServerTool(Name = "bookstack_pages_delete")]
+    [Description("Delete a page by ID. This moves the page to the recycle bin.")]
+    public async Task<string> DeletePageAsync(
+        [Description("The page ID. Must be a positive integer.")] int id,
+        CancellationToken ct = default)
+    {
+        if (id <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+        }
+
+        try
+        {
+            await _client.DeletePageAsync(id, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(new { success = true, message = $"Page {id} deleted successfully" }, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error deleting page {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
+
+    [McpServerTool(Name = "bookstack_pages_export")]
+    [Description("Export a page in the specified format. Returns the raw export content as a string.")]
+    public async Task<string> ExportPageAsync(
+        [Description("The page ID. Must be a positive integer.")] int id,
+        [Description("Export format. Must be one of: html, pdf, plaintext, markdown.")] string format,
+        CancellationToken ct = default)
+    {
+        if (id <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+        }
+
+        if (!Enum.TryParse<ExportFormat>(format, ignoreCase: true, out var exportFormat))
+        {
+            return JsonSerializer.Serialize(
+                new { error = "validation_error", message = $"Invalid export format '{format}'. Must be one of: html, pdf, plaintext, markdown." },
+                _jsonOptions);
+        }
+
+        try
+        {
+            return await _client.ExportPageAsync(id, exportFormat, ct).ConfigureAwait(false);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error exporting page {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 }

--- a/src/BookStack.Mcp.Server/tools/shelves/ShelfToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/shelves/ShelfToolHandler.cs
@@ -1,5 +1,8 @@
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Text.Json;
 using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 
@@ -11,27 +14,168 @@ internal sealed class ShelfToolHandler(IBookStackApiClient client, ILogger<Shelf
     private readonly IBookStackApiClient _client = client;
     private readonly ILogger<ShelfToolHandler> _logger = logger;
 
-    [McpServerTool(Name = "bookstack_shelves_list"), Description("List all shelves in BookStack")]
-    public Task<string> ListShelvesAsync(CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
 
-    [McpServerTool(Name = "bookstack_shelves_read"), Description("Get a shelf by ID")]
-    public Task<string> ReadShelfAsync(
-        [Description("The shelf ID")] int id, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+    [McpServerTool(Name = "bookstack_shelves_list")]
+    [Description("List all bookshelves visible to the authenticated user with pagination options. Shelves group related books into collections.")]
+    public async Task<string> ListShelvesAsync(
+        [Description("Number of shelves to return (1–500). Defaults to 20.")] int? count = null,
+        [Description("Number of shelves to skip for pagination. Defaults to 0.")] int? offset = null,
+        [Description("Sort field: name, created_at, updated_at. Defaults to name.")] string? sort = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var query = (count.HasValue || offset.HasValue || sort is not null)
+                ? new ListQueryParams { Count = count, Offset = offset, Sort = sort }
+                : null;
+            var result = await _client.ListShelvesAsync(query, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 422)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error listing shelves: {Message}", ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 
-    [McpServerTool(Name = "bookstack_shelves_create"), Description("Create a new shelf")]
-    public Task<string> CreateShelfAsync(
-        [Description("The shelf name")] string name, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+    [McpServerTool(Name = "bookstack_shelves_read")]
+    [Description("Get a single bookshelf by ID, including the list of books assigned to it.")]
+    public async Task<string> ReadShelfAsync(
+        [Description("The shelf ID. Must be a positive integer.")] int id,
+        CancellationToken ct = default)
+    {
+        if (id <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+        }
 
-    [McpServerTool(Name = "bookstack_shelves_update"), Description("Update an existing shelf")]
-    public Task<string> UpdateShelfAsync(
-        [Description("The shelf ID")] int id, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+        try
+        {
+            var result = await _client.GetShelfAsync(id, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error reading shelf {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 
-    [McpServerTool(Name = "bookstack_shelves_delete"), Description("Delete a shelf by ID")]
-    public Task<string> DeleteShelfAsync(
-        [Description("The shelf ID")] int id, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #9");
+    [McpServerTool(Name = "bookstack_shelves_create")]
+    [Description("Create a new bookshelf. Optionally assign books to the shelf at creation time.")]
+    public async Task<string> CreateShelfAsync(
+        [Description("The shelf name (required, max 255 characters).")] string name,
+        [Description("Plain text description (max 1900 characters).")] string? description = null,
+        [Description("HTML description (max 2000 characters). Overrides description if both provided.")] string? descriptionHtml = null,
+        [Description("Tags to assign. Each object must have name and value string properties.")] IList<Tag>? tags = null,
+        [Description("List of book IDs to assign to this shelf. Providing this array on update replaces ALL currently assigned books.")] IList<int>? books = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var request = new CreateShelfRequest
+            {
+                Name = name,
+                Description = description,
+                DescriptionHtml = descriptionHtml,
+                Tags = tags,
+                Books = books,
+            };
+            var result = await _client.CreateShelfAsync(request, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 422)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error creating shelf: {Message}", ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
+
+    [McpServerTool(Name = "bookstack_shelves_update")]
+    [Description("Update an existing shelf's name, description, tags, or assigned books.")]
+    public async Task<string> UpdateShelfAsync(
+        [Description("The shelf ID. Must be a positive integer.")] int id,
+        [Description("New name for the shelf (max 255 characters).")] string? name = null,
+        [Description("Plain text description (max 1900 characters).")] string? description = null,
+        [Description("HTML description (max 2000 characters). Overrides description if both provided.")] string? descriptionHtml = null,
+        [Description("Tags to assign. Providing this array replaces ALL existing tags. Omit to leave tags unchanged.")] IList<Tag>? tags = null,
+        [Description("List of book IDs to assign to this shelf. Providing this array replaces ALL currently assigned books. Omit to leave books unchanged.")] IList<int>? books = null,
+        CancellationToken ct = default)
+    {
+        if (id <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+        }
+
+        try
+        {
+            var request = new UpdateShelfRequest
+            {
+                Name = name,
+                Description = description,
+                DescriptionHtml = descriptionHtml,
+                Tags = tags,
+                Books = books,
+            };
+            var result = await _client.UpdateShelfAsync(id, request, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 422)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error updating shelf {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
+
+    [McpServerTool(Name = "bookstack_shelves_delete")]
+    [Description("Delete a bookshelf by ID. The shelf's assigned books are NOT deleted.")]
+    public async Task<string> DeleteShelfAsync(
+        [Description("The shelf ID. Must be a positive integer.")] int id,
+        CancellationToken ct = default)
+    {
+        if (id <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "validation_error", message = $"id must be a positive integer, got {id}." }, _jsonOptions);
+        }
+
+        try
+        {
+            await _client.DeleteShelfAsync(id, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(new { success = true, message = $"Shelf {id} deleted successfully" }, _jsonOptions);
+        }
+        catch (BookStackApiException ex) when (ex.StatusCode == 404)
+        {
+            return JsonSerializer.Serialize(new { error = "not_found", message = ex.ErrorMessage }, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error deleting shelf {Id}: {Message}", id, ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 }

--- a/tests/BookStack.Mcp.Server.Tests/resources/books/BookResourceHandlerTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/resources/books/BookResourceHandlerTests.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Resources.Books;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BookStack.Mcp.Server.Tests.Resources.Books;
+
+public sealed class BookResourceHandlerTests
+{
+    private readonly Mock<IBookStackApiClient> _client = new();
+    private readonly BookResourceHandler _handler;
+
+    public BookResourceHandlerTests()
+    {
+        _handler = new BookResourceHandler(_client.Object, NullLogger<BookResourceHandler>.Instance);
+    }
+
+    [Test]
+    public async Task GetBooksResource_ReturnsSerializedListResponse()
+    {
+        _client.Setup(c => c.ListBooksAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListResponse<Book> { Data = [new Book { Id = 1 }], Total = 1 });
+
+        var result = await _handler.GetBooksAsync().ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("total").GetInt32().Should().Be(1);
+        doc.RootElement.GetProperty("data").GetArrayLength().Should().Be(1);
+    }
+
+    [Test]
+    public async Task GetBookByIdResource_ValidId_ReturnsSerializedBookWithContents()
+    {
+        _client.Setup(c => c.GetBookAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BookWithContents { Id = 7 });
+
+        var result = await _handler.GetBookAsync(7).ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("id").GetInt32().Should().Be(7);
+    }
+}

--- a/tests/BookStack.Mcp.Server.Tests/resources/pages/PageResourceHandlerTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/resources/pages/PageResourceHandlerTests.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Resources.Pages;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BookStack.Mcp.Server.Tests.Resources.Pages;
+
+public sealed class PageResourceHandlerTests
+{
+    private readonly Mock<IBookStackApiClient> _client = new();
+    private readonly PageResourceHandler _handler;
+
+    public PageResourceHandlerTests()
+    {
+        _handler = new PageResourceHandler(_client.Object, NullLogger<PageResourceHandler>.Instance);
+    }
+
+    [Test]
+    public async Task GetPagesResource_ReturnsSerializedListResponse()
+    {
+        _client.Setup(c => c.ListPagesAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListResponse<Page> { Data = [new Page { Id = 3 }], Total = 1 });
+
+        var result = await _handler.GetPagesAsync().ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("total").GetInt32().Should().Be(1);
+    }
+
+    [Test]
+    public async Task GetPageByIdResource_ValidId_ReturnsSerializedPageWithContent()
+    {
+        _client.Setup(c => c.GetPageAsync(3, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PageWithContent { Id = 3, Html = "<p>Content</p>" });
+
+        var result = await _handler.GetPageAsync(3).ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("html").GetString().Should().Be("<p>Content</p>");
+    }
+}

--- a/tests/BookStack.Mcp.Server.Tests/tools/books/BookToolHandlerTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/tools/books/BookToolHandlerTests.cs
@@ -1,0 +1,148 @@
+using System.Text.Json;
+using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Tools.Books;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BookStack.Mcp.Server.Tests.Tools.Books;
+
+public sealed class BookToolHandlerTests
+{
+    private readonly Mock<IBookStackApiClient> _client = new();
+    private readonly BookToolHandler _handler;
+
+    public BookToolHandlerTests()
+    {
+        _handler = new BookToolHandler(_client.Object, NullLogger<BookToolHandler>.Instance);
+    }
+
+    [Test]
+    public async Task ListBooksAsync_NoParams_CallsClientWithNullQuery()
+    {
+        _client.Setup(c => c.ListBooksAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListResponse<Book>());
+
+        await _handler.ListBooksAsync().ConfigureAwait(false);
+
+        _client.Verify(c => c.ListBooksAsync(null, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task ListBooksAsync_WithCountAndOffset_PassesParams()
+    {
+        _client.Setup(c => c.ListBooksAsync(It.IsAny<ListQueryParams?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListResponse<Book>());
+
+        await _handler.ListBooksAsync(count: 5, offset: 10).ConfigureAwait(false);
+
+        _client.Verify(
+            c => c.ListBooksAsync(
+                It.Is<ListQueryParams?>(q => q != null && q.Count == 5 && q.Offset == 10),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task ReadBookAsync_ValidId_ReturnsSerializedBook()
+    {
+        _client.Setup(c => c.GetBookAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BookWithContents { Id = 42 });
+
+        var result = await _handler.ReadBookAsync(42).ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("id").GetInt32().Should().Be(42);
+    }
+
+    [Test]
+    public async Task ReadBookAsync_NotFound_ReturnsErrorJson()
+    {
+        _client.Setup(c => c.GetBookAsync(999, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new BookStackApiException(404, "Not found", null));
+
+        var result = await _handler.ReadBookAsync(999).ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("error").GetString().Should().Be("not_found");
+    }
+
+    [Test]
+    public async Task CreateBookAsync_ValidName_ReturnsSerializedBook()
+    {
+        _client.Setup(c => c.CreateBookAsync(It.IsAny<CreateBookRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Book { Id = 1, Name = "Test" });
+
+        var result = await _handler.CreateBookAsync("Test").ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("name").GetString().Should().Be("Test");
+        _client.Verify(
+            c => c.CreateBookAsync(
+                It.Is<CreateBookRequest>(r => r.Name == "Test"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task CreateBookAsync_WithTags_PassesTagsToRequest()
+    {
+        _client.Setup(c => c.CreateBookAsync(It.IsAny<CreateBookRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Book { Id = 1, Name = "T" });
+
+        await _handler.CreateBookAsync("T", tags: [new Tag { Name = "env", Value = "prod" }]).ConfigureAwait(false);
+
+        _client.Verify(
+            c => c.CreateBookAsync(
+                It.Is<CreateBookRequest>(r => r.Tags != null && r.Tags.Count == 1 && r.Tags[0].Name == "env"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task UpdateBookAsync_ValidId_ReturnsUpdatedBook()
+    {
+        _client.Setup(c => c.UpdateBookAsync(5, It.IsAny<UpdateBookRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Book { Id = 5, Name = "Updated" });
+
+        var result = await _handler.UpdateBookAsync(5, name: "Updated").ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("name").GetString().Should().Be("Updated");
+    }
+
+    [Test]
+    public async Task DeleteBookAsync_ValidId_ReturnsSuccessJson()
+    {
+        _client.Setup(c => c.DeleteBookAsync(3, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _handler.DeleteBookAsync(3).ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        doc.RootElement.GetProperty("message").GetString().Should().Contain("3");
+    }
+
+    [Test]
+    public async Task ExportBookAsync_InvalidFormat_ReturnsValidationError()
+    {
+        var result = await _handler.ExportBookAsync(1, "docx").ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("error").GetString().Should().Be("validation_error");
+        _client.Verify(c => c.ExportBookAsync(It.IsAny<int>(), It.IsAny<ExportFormat>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ExportBookAsync_ValidFormatMarkdown_ReturnsExportString()
+    {
+        _client.Setup(c => c.ExportBookAsync(1, ExportFormat.Markdown, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("# My Book");
+
+        var result = await _handler.ExportBookAsync(1, "markdown").ConfigureAwait(false);
+
+        result.Should().Be("# My Book");
+    }
+}

--- a/tests/BookStack.Mcp.Server.Tests/tools/chapters/ChapterToolHandlerTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/tools/chapters/ChapterToolHandlerTests.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Tools.Chapters;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BookStack.Mcp.Server.Tests.Tools.Chapters;
+
+public sealed class ChapterToolHandlerTests
+{
+    private readonly Mock<IBookStackApiClient> _client = new();
+    private readonly ChapterToolHandler _handler;
+
+    public ChapterToolHandlerTests()
+    {
+        _handler = new ChapterToolHandler(_client.Object, NullLogger<ChapterToolHandler>.Instance);
+    }
+
+    [Test]
+    public async Task CreateChapterAsync_ValidBookIdAndName_ReturnsSerializedChapter()
+    {
+        _client.Setup(c => c.CreateChapterAsync(It.IsAny<CreateChapterRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Chapter { Id = 10, BookId = 2, Name = "Ch1" });
+
+        var result = await _handler.CreateChapterAsync(bookId: 2, name: "Ch1").ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("bookId").GetInt32().Should().Be(2);
+        _client.Verify(
+            c => c.CreateChapterAsync(
+                It.Is<CreateChapterRequest>(r => r.BookId == 2 && r.Name == "Ch1"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task ReadChapterAsync_NotFound_ReturnsErrorJson()
+    {
+        _client.Setup(c => c.GetChapterAsync(999, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new BookStackApiException(404, "Not found", null));
+
+        var result = await _handler.ReadChapterAsync(999).ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("error").GetString().Should().Be("not_found");
+    }
+
+    [Test]
+    public async Task DeleteChapterAsync_ValidId_ReturnsSuccessJson()
+    {
+        _client.Setup(c => c.DeleteChapterAsync(7, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _handler.DeleteChapterAsync(7).ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        doc.RootElement.GetProperty("message").GetString().Should().Contain("7");
+    }
+}

--- a/tests/BookStack.Mcp.Server.Tests/tools/pages/PageToolHandlerTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/tools/pages/PageToolHandlerTests.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Tools.Pages;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BookStack.Mcp.Server.Tests.Tools.Pages;
+
+public sealed class PageToolHandlerTests
+{
+    private readonly Mock<IBookStackApiClient> _client = new();
+    private readonly PageToolHandler _handler;
+
+    public PageToolHandlerTests()
+    {
+        _handler = new PageToolHandler(_client.Object, NullLogger<PageToolHandler>.Instance);
+    }
+
+    [Test]
+    public async Task CreatePageAsync_NoParentId_ReturnsValidationError()
+    {
+        var result = await _handler.CreatePageAsync("Page1").ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("error").GetString().Should().Be("validation_error");
+        var message = doc.RootElement.GetProperty("message").GetString();
+        (message!.Contains("bookId") || message.Contains("chapterId")).Should().BeTrue();
+        _client.Verify(c => c.CreatePageAsync(It.IsAny<CreatePageRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task CreatePageAsync_WithBookId_CallsClientWithCorrectRequest()
+    {
+        _client.Setup(c => c.CreatePageAsync(It.IsAny<CreatePageRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Page { Id = 5, BookId = 3 });
+
+        var result = await _handler.CreatePageAsync("Page1", bookId: 3).ConfigureAwait(false);
+
+        JsonDocument.Parse(result); // validate JSON
+        _client.Verify(
+            c => c.CreatePageAsync(
+                It.Is<CreatePageRequest>(r => r.BookId == 3 && r.Name == "Page1" && r.ChapterId == null),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task CreatePageAsync_WithMarkdown_SetsMarkdownField()
+    {
+        _client.Setup(c => c.CreatePageAsync(It.IsAny<CreatePageRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Page { Id = 6 });
+
+        await _handler.CreatePageAsync("Md Page", chapterId: 1, markdown: "# Hello").ConfigureAwait(false);
+
+        _client.Verify(
+            c => c.CreatePageAsync(
+                It.Is<CreatePageRequest>(r => r.Markdown == "# Hello" && r.Html == null),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task ReadPageAsync_ValidId_ReturnsPageWithContent()
+    {
+        _client.Setup(c => c.GetPageAsync(8, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PageWithContent { Id = 8, Html = "<p>Hi</p>" });
+
+        var result = await _handler.ReadPageAsync(8).ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("html").GetString().Should().Be("<p>Hi</p>");
+    }
+
+    [Test]
+    public async Task DeletePageAsync_NotFound_ReturnsErrorJson()
+    {
+        _client.Setup(c => c.DeletePageAsync(99, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new BookStackApiException(404, "Not found", null));
+
+        var result = await _handler.DeletePageAsync(99).ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("error").GetString().Should().Be("not_found");
+    }
+}

--- a/tests/BookStack.Mcp.Server.Tests/tools/shelves/ShelfToolHandlerTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/tools/shelves/ShelfToolHandlerTests.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Tools.Shelves;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BookStack.Mcp.Server.Tests.Tools.Shelves;
+
+public sealed class ShelfToolHandlerTests
+{
+    private readonly Mock<IBookStackApiClient> _client = new();
+    private readonly ShelfToolHandler _handler;
+
+    public ShelfToolHandlerTests()
+    {
+        _handler = new ShelfToolHandler(_client.Object, NullLogger<ShelfToolHandler>.Instance);
+    }
+
+    [Test]
+    public async Task CreateShelfAsync_WithBooks_SetsBooksList()
+    {
+        _client.Setup(c => c.CreateShelfAsync(It.IsAny<CreateShelfRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Bookshelf { Id = 4, Name = "My Shelf" });
+
+        await _handler.CreateShelfAsync("My Shelf", books: [1, 2, 3]).ConfigureAwait(false);
+
+        _client.Verify(
+            c => c.CreateShelfAsync(
+                It.Is<CreateShelfRequest>(r => r.Books != null && r.Books.Count == 3),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task UpdateShelfAsync_WithBooks_ReplacesExistingBooks()
+    {
+        _client.Setup(c => c.UpdateShelfAsync(4, It.IsAny<UpdateShelfRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Bookshelf { Id = 4 });
+
+        await _handler.UpdateShelfAsync(4, books: [5]).ConfigureAwait(false);
+
+        _client.Verify(
+            c => c.UpdateShelfAsync(
+                4,
+                It.Is<UpdateShelfRequest>(r => r.Books != null && r.Books.Count == 1 && r.Books[0] == 5),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task DeleteShelfAsync_ValidId_ReturnsSuccessJson()
+    {
+        _client.Setup(c => c.DeleteShelfAsync(4, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _handler.DeleteShelfAsync(4).ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        doc.RootElement.GetProperty("message").GetString().Should().Contain("4");
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #7 — all Books, Chapters, Pages, and Shelves CRUD tools and MCP resources.

## Changes

### Tool handlers (8 handler methods each)

| Handler | Tools |
|---|---|
| `BookToolHandler` | `list_books`, `read_book`, `create_book`, `update_book`, `delete_book`, `export_book` |
| `ChapterToolHandler` | `list_chapters`, `read_chapter`, `create_chapter`, `update_chapter`, `delete_chapter`, `export_chapter` |
| `PageToolHandler` | `list_pages`, `read_page`, `create_page`, `update_page`, `delete_page`, `export_page` |
| `ShelfToolHandler` | `list_shelves`, `read_shelf`, `create_shelf`, `update_shelf`, `delete_shelf` |

`PageToolHandler.CreatePageAsync` validates that exactly one of `bookId` or `chapterId` is provided.

### Resource handlers

`bookstack://books`, `bookstack://books/{id}`, `bookstack://chapters`, `bookstack://chapters/{id}`, `bookstack://pages`, `bookstack://pages/{id}`, `bookstack://shelves`, `bookstack://shelves/{id}`

### Tests

25 new unit tests across 6 test files; total test count: 66/66 passing.

## Closes

Closes #7, #43, #44, #45, #46, #47, #48, #49, #50