### PR TITLE
feat(#12): search tool and search resource handler

### DIFF
--- a/src/BookStack.Mcp.Server/resources/search/SearchResourceHandler.cs
+++ b/src/BookStack.Mcp.Server/resources/search/SearchResourceHandler.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel;
+using System.Text.Json;
 using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 
@@ -12,8 +14,26 @@ internal sealed class SearchResourceHandler(
     private readonly IBookStackApiClient _client = client;
     private readonly ILogger<SearchResourceHandler> _logger = logger;
 
-    [McpServerResource(UriTemplate = "bookstack://search", Name = "Search")]
-    [Description("Search results from the BookStack instance")]
-    public Task<string> GetSearchAsync(CancellationToken ct)
-        => throw new NotImplementedException("Implemented in a future issue");
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
+
+    [McpServerResource(UriTemplate = "bookstack://search/{query}", Name = "Search")]
+    [Description("Search results for a given query across all BookStack content.")]
+    public async Task<string> GetSearchAsync(string query, CancellationToken ct = default)
+    {
+        try
+        {
+            var request = new SearchRequest { Query = query };
+            var result = await _client.SearchAsync(request, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error searching content: {Message}", ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 }

--- a/src/BookStack.Mcp.Server/tools/search/SearchToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/search/SearchToolHandler.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel;
+using System.Text.Json;
 using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 
@@ -11,8 +13,42 @@ internal sealed class SearchToolHandler(IBookStackApiClient client, ILogger<Sear
     private readonly IBookStackApiClient _client = client;
     private readonly ILogger<SearchToolHandler> _logger = logger;
 
-    [McpServerTool(Name = "bookstack_search"), Description("Search for content across BookStack")]
-    public Task<string> SearchAsync(
-        [Description("The search query")] string query, CancellationToken ct)
-        => throw new NotImplementedException("Implemented in Issue #12");
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
+
+    [McpServerTool(Name = "bookstack_search")]
+    [Description("Search across all BookStack content (pages, books, chapters, shelves). Supports advanced query syntax: \"exact phrase\", {type:page|book|chapter|shelf}, {tag:name=value}, {created_by:me}. Note: page results contain snippets only — use bookstack_pages_read to retrieve full content.")]
+    public async Task<string> SearchAsync(
+        [Description("Search query string. Required. Supports advanced syntax filters.")] string query,
+        [Description("Page number for pagination. Minimum 1. Defaults to 1.")] int? page = null,
+        [Description("Results per page. Range 1–100. Defaults to 20.")] int? count = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return JsonSerializer.Serialize(
+                new { error = "validation_error", message = "query is required and cannot be empty." },
+                _jsonOptions);
+        }
+
+        try
+        {
+            var request = new SearchRequest
+            {
+                Query = query,
+                Page = page,
+                Count = count,
+            };
+            var result = await _client.SearchAsync(request, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, _jsonOptions);
+        }
+        catch (BookStackApiException ex)
+        {
+            _logger.LogError(ex, "BookStack API error searching content: {Message}", ex.Message);
+            return JsonSerializer.Serialize(new { error = "api_error", message = ex.ErrorMessage }, _jsonOptions);
+        }
+    }
 }

--- a/tests/BookStack.Mcp.Server.Tests/resources/search/SearchResourceHandlerTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/resources/search/SearchResourceHandlerTests.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Resources.Search;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BookStack.Mcp.Server.Tests.Resources.Search;
+
+public sealed class SearchResourceHandlerTests
+{
+    private readonly Mock<IBookStackApiClient> _client = new();
+    private readonly SearchResourceHandler _handler;
+
+    public SearchResourceHandlerTests()
+    {
+        _handler = new SearchResourceHandler(_client.Object, NullLogger<SearchResourceHandler>.Instance);
+    }
+
+    [Test]
+    public async Task GetSearchAsync_ValidQuery_ReturnsSerializedResult()
+    {
+        var item = new SearchResultItem { Id = 3, Name = "API Docs", Type = "page" };
+        _client.Setup(c => c.SearchAsync(
+                It.Is<SearchRequest>(r => r.Query == "API"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SearchResult { Total = 1, Data = [item] });
+
+        var result = await _handler.GetSearchAsync("API").ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("total").GetInt32().Should().Be(1);
+        doc.RootElement.GetProperty("data")[0].GetProperty("name").GetString().Should().Be("API Docs");
+    }
+
+    [Test]
+    public async Task GetSearchAsync_ApiException_ReturnsErrorJson()
+    {
+        _client.Setup(c => c.SearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new BookStackApiException(503, "Service unavailable", null));
+
+        var result = await _handler.GetSearchAsync("anything").ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("error").GetString().Should().Be("api_error");
+    }
+}

--- a/tests/BookStack.Mcp.Server.Tests/tools/search/SearchToolHandlerTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/tools/search/SearchToolHandlerTests.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Tools.Search;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BookStack.Mcp.Server.Tests.Tools.Search;
+
+public sealed class SearchToolHandlerTests
+{
+    private readonly Mock<IBookStackApiClient> _client = new();
+    private readonly SearchToolHandler _handler;
+
+    public SearchToolHandlerTests()
+    {
+        _handler = new SearchToolHandler(_client.Object, NullLogger<SearchToolHandler>.Instance);
+    }
+
+    [Test]
+    public async Task SearchAsync_EmptyQuery_ReturnsValidationError()
+    {
+        var result = await _handler.SearchAsync("   ").ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("error").GetString().Should().Be("validation_error");
+        _client.Verify(c => c.SearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task SearchAsync_ValidQuery_CallsClientWithQuery()
+    {
+        _client.Setup(c => c.SearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SearchResult { Total = 0, Data = [] });
+
+        await _handler.SearchAsync("bookstack").ConfigureAwait(false);
+
+        _client.Verify(
+            c => c.SearchAsync(
+                It.Is<SearchRequest>(r => r.Query == "bookstack" && r.Page == null && r.Count == null),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task SearchAsync_WithPageAndCount_PassesParams()
+    {
+        _client.Setup(c => c.SearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SearchResult { Total = 0, Data = [] });
+
+        await _handler.SearchAsync("API", page: 2, count: 10).ConfigureAwait(false);
+
+        _client.Verify(
+            c => c.SearchAsync(
+                It.Is<SearchRequest>(r => r.Query == "API" && r.Page == 2 && r.Count == 10),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task SearchAsync_ReturnsSerializedResult()
+    {
+        var item = new SearchResultItem { Id = 5, Name = "My Page", Type = "page" };
+        _client.Setup(c => c.SearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SearchResult { Total = 1, Data = [item] });
+
+        var result = await _handler.SearchAsync("My Page").ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("total").GetInt32().Should().Be(1);
+        doc.RootElement.GetProperty("data")[0].GetProperty("id").GetInt32().Should().Be(5);
+    }
+
+    [Test]
+    public async Task SearchAsync_ApiException_ReturnsErrorJson()
+    {
+        _client.Setup(c => c.SearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new BookStackApiException(500, "Internal error", null));
+
+        var result = await _handler.SearchAsync("query").ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("error").GetString().Should().Be("api_error");
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #12 — Search Tool & Resources.

## Changes

### `SearchToolHandler` (`bookstack_search`)
- `query` param (required — returns `validation_error` if blank)
- Optional `page` and `count` pagination params
- Description includes advanced query syntax hints (`{type:page}`, `{tag:name=value}`, etc.)
- Catches `BookStackApiException` → `{ error, message }` JSON

### `SearchResourceHandler` (`bookstack://search/{query}`)
- URI template resource accepting a query parameter
- Returns serialized `SearchResult` (total, from, to, data[])

### Tests
- 5 `SearchToolHandlerTests`: empty query, valid query, page+count params, serialized result, API exception
- 2 `SearchResourceHandlerTests`: valid query, API exception

Total tests: 73/73 passing.

Closes #12