### PR TITLE
chore: hide unimplemented handlers from MCP discovery

### DIFF
--- a/src/BookStack.Mcp.Server/resources/users/UserResourceHandler.cs
+++ b/src/BookStack.Mcp.Server/resources/users/UserResourceHandler.cs
@@ -5,7 +5,7 @@ using ModelContextProtocol.Server;
 
 namespace BookStack.Mcp.Server.Resources.Users;
 
-[McpServerResourceType]
+// [McpServerResourceType] — hidden until #9 is implemented
 internal sealed class UserResourceHandler(
     IBookStackApiClient client, ILogger<UserResourceHandler> logger)
 {

--- a/src/BookStack.Mcp.Server/tools/attachments/AttachmentToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/attachments/AttachmentToolHandler.cs
@@ -5,7 +5,7 @@ using ModelContextProtocol.Server;
 
 namespace BookStack.Mcp.Server.Tools.Attachments;
 
-[McpServerToolType]
+// [McpServerToolType] — hidden until #16 is implemented
 internal sealed class AttachmentToolHandler(IBookStackApiClient client, ILogger<AttachmentToolHandler> logger)
 {
     private readonly IBookStackApiClient _client = client;

--- a/src/BookStack.Mcp.Server/tools/audit/AuditToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/audit/AuditToolHandler.cs
@@ -5,7 +5,7 @@ using ModelContextProtocol.Server;
 
 namespace BookStack.Mcp.Server.Tools.Audit;
 
-[McpServerToolType]
+// [McpServerToolType] — hidden until #6 is implemented
 internal sealed class AuditToolHandler(IBookStackApiClient client, ILogger<AuditToolHandler> logger)
 {
     private readonly IBookStackApiClient _client = client;

--- a/src/BookStack.Mcp.Server/tools/images/ImageToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/images/ImageToolHandler.cs
@@ -5,7 +5,7 @@ using ModelContextProtocol.Server;
 
 namespace BookStack.Mcp.Server.Tools.Images;
 
-[McpServerToolType]
+// [McpServerToolType] — hidden until #16 is implemented
 internal sealed class ImageToolHandler(IBookStackApiClient client, ILogger<ImageToolHandler> logger)
 {
     private readonly IBookStackApiClient _client = client;

--- a/src/BookStack.Mcp.Server/tools/permissions/PermissionToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/permissions/PermissionToolHandler.cs
@@ -5,7 +5,7 @@ using ModelContextProtocol.Server;
 
 namespace BookStack.Mcp.Server.Tools.Permissions;
 
-[McpServerToolType]
+// [McpServerToolType] — hidden until #6 is implemented
 internal sealed class PermissionToolHandler(IBookStackApiClient client, ILogger<PermissionToolHandler> logger)
 {
     private readonly IBookStackApiClient _client = client;

--- a/src/BookStack.Mcp.Server/tools/recyclebin/RecycleBinToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/recyclebin/RecycleBinToolHandler.cs
@@ -5,7 +5,7 @@ using ModelContextProtocol.Server;
 
 namespace BookStack.Mcp.Server.Tools.RecycleBin;
 
-[McpServerToolType]
+// [McpServerToolType] — hidden until #6 is implemented
 internal sealed class RecycleBinToolHandler(IBookStackApiClient client, ILogger<RecycleBinToolHandler> logger)
 {
     private readonly IBookStackApiClient _client = client;

--- a/src/BookStack.Mcp.Server/tools/roles/RoleToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/roles/RoleToolHandler.cs
@@ -5,7 +5,7 @@ using ModelContextProtocol.Server;
 
 namespace BookStack.Mcp.Server.Tools.Roles;
 
-[McpServerToolType]
+// [McpServerToolType] — hidden until #9 is implemented
 internal sealed class RoleToolHandler(IBookStackApiClient client, ILogger<RoleToolHandler> logger)
 {
     private readonly IBookStackApiClient _client = client;

--- a/src/BookStack.Mcp.Server/tools/server-info/ServerInfoToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/server-info/ServerInfoToolHandler.cs
@@ -5,7 +5,7 @@ using ModelContextProtocol.Server;
 
 namespace BookStack.Mcp.Server.Tools.ServerInfo;
 
-[McpServerToolType]
+// [McpServerToolType] — hidden until #10 is implemented
 internal sealed class ServerInfoToolHandler(IBookStackApiClient client, ILogger<ServerInfoToolHandler> logger)
 {
     private readonly IBookStackApiClient _client = client;

--- a/src/BookStack.Mcp.Server/tools/system/SystemToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/system/SystemToolHandler.cs
@@ -5,7 +5,7 @@ using ModelContextProtocol.Server;
 
 namespace BookStack.Mcp.Server.Tools.System;
 
-[McpServerToolType]
+// [McpServerToolType] — hidden until #10 is implemented
 internal sealed class SystemToolHandler(IBookStackApiClient client, ILogger<SystemToolHandler> logger)
 {
     private readonly IBookStackApiClient _client = client;

--- a/src/BookStack.Mcp.Server/tools/users/UserToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/users/UserToolHandler.cs
@@ -5,7 +5,7 @@ using ModelContextProtocol.Server;
 
 namespace BookStack.Mcp.Server.Tools.Users;
 
-[McpServerToolType]
+// [McpServerToolType] — hidden until #9 is implemented
 internal sealed class UserToolHandler(IBookStackApiClient client, ILogger<UserToolHandler> logger)
 {
     private readonly IBookStackApiClient _client = client;

--- a/tests/BookStack.Mcp.Server.Tests/server/McpHandlerAttributeTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/server/McpHandlerAttributeTests.cs
@@ -18,7 +18,7 @@ public sealed class McpHandlerAttributeTests
     }
 
     [Test]
-    public async Task ServerAssembly_ContainsAtLeastFourteenToolHandlerTypes()
+    public async Task ServerAssembly_ContainsAtLeastFiveToolHandlerTypes()
     {
         var assembly = typeof(BookToolHandler).Assembly;
         var toolTypes = assembly.GetTypes()
@@ -26,11 +26,11 @@ public sealed class McpHandlerAttributeTests
             .ToList();
 
         var count = toolTypes.Count;
-        await Assert.That(count).IsGreaterThanOrEqualTo(14);
+        await Assert.That(count).IsGreaterThanOrEqualTo(5);
     }
 
     [Test]
-    public async Task ServerAssembly_ContainsAtLeastSixResourceHandlerTypes()
+    public async Task ServerAssembly_ContainsAtLeastFiveResourceHandlerTypes()
     {
         var assembly = typeof(BookToolHandler).Assembly;
         var resourceTypes = assembly.GetTypes()
@@ -38,7 +38,7 @@ public sealed class McpHandlerAttributeTests
             .ToList();
 
         var count = resourceTypes.Count;
-        await Assert.That(count).IsGreaterThanOrEqualTo(6);
+        await Assert.That(count).IsGreaterThanOrEqualTo(5);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Removes `[McpServerToolType]` and `[McpServerResourceType]` attributes from stub handlers that throw `NotImplementedException`, so MCP clients never see tools that can't be executed.

### Hidden handlers

| Handler | Attribute removed | Related issue |
|---|---|---|
| UsersToolHandler | `[McpServerToolType]` | #9 |
| RolesToolHandler | `[McpServerToolType]` | #9 |
| AttachmentToolHandler | `[McpServerToolType]` | #16 |
| ImageToolHandler | `[McpServerToolType]` | #16 |
| RecycleBinToolHandler | `[McpServerToolType]` | #6 |
| PermissionToolHandler | `[McpServerToolType]` | #6 |
| AuditToolHandler | `[McpServerToolType]` | #6 |
| SystemToolHandler | `[McpServerToolType]` | #10 |
| ServerInfoToolHandler | `[McpServerToolType]` | #10 |
| UserResourceHandler | `[McpServerResourceType]` | #9 |

### Re-enabling

Restore the attribute in the relevant handler file when the implementing issue is picked up.

### Tests

Assembly scan thresholds updated from 14/6 → 5/5 to reflect only implemented handlers.