### PR TITLE
feat(#54): book/shelf scope filtering

### DIFF
--- a/docs/architecture/decisions/ADR-0014-scope-filter-architecture.md
+++ b/docs/architecture/decisions/ADR-0014-scope-filter-architecture.md
@@ -1,0 +1,159 @@
+# ADR-0014: Scope Filter Architecture for Book/Shelf Scope Filtering
+
+**Status**: Accepted
+**Date**: 2026-04-25
+**Author**: GitHub Copilot
+**Deciders**: Engineering team
+
+---
+
+## Context
+
+Feature FEAT-0054 introduces `BOOKSTACK_SCOPED_BOOKS` and `BOOKSTACK_SCOPED_SHELVES` environment
+variables that restrict list and search results to a configured subset of books/shelves. Four
+architectural decisions need to be made before implementation:
+
+1. Where does filtering logic execute — in the MCP tool layer or passed to the BookStack API as
+   query parameters?
+2. How is the scope configuration (`ScopeFilterOptions`) registered in the DI container?
+3. Where does the shared filter predicate live — inline in each handler or in a shared helper?
+4. How are the comma-separated env var values parsed into a form that `IConfiguration` can bind to
+   `IReadOnlyList<string>`?
+
+These decisions must be consistent with existing patterns: `BookStackApiClientOptions` registered
+via `IOptions<T>`, `MapBookStackEnvVars()` building an in-memory `IConfiguration` dictionary, and
+primary-constructor DI injection in tool and resource handlers.
+
+## Decision
+
+**We will implement scope filtering as application-side post-fetch filtering in the MCP tool
+layer, with `IOptions<ScopeFilterOptions>` DI registration, a shared static `ScopeFilter` helper,
+and indexed `IConfiguration` key generation in `MapBookStackEnvVars()`.**
+
+Specifically:
+
+- `ScopeFilterOptions` is a new `sealed` class in `BookStack.Mcp.Server.Config`, registered with
+  `services.Configure<ScopeFilterOptions>(configuration.GetSection("BookStack"))` inside
+  `AddBookStackApiClient()`.
+- `IOptions<ScopeFilterOptions>` is injected via primary constructor into `BookToolHandler`,
+  `ShelfToolHandler`, `SearchToolHandler`, `BookResourceHandler`, and `ShelfResourceHandler` — the
+  only five handlers affected by scope.
+- A `static internal class ScopeFilter` in `src/BookStack.Mcp.Server/config/ScopeFilter.cs`
+  provides a single `MatchesScope(int id, string slug, IReadOnlyList<string> scope)` method.
+  Filtering is bypassed entirely when the scope list is empty.
+- `MapBookStackEnvVars()` splits `BOOKSTACK_SCOPED_BOOKS` and `BOOKSTACK_SCOPED_SHELVES` on
+  commas, trims whitespace, validates each entry against `^[a-zA-Z0-9_-]+$`, discards invalid
+  entries with a logged warning, and writes the valid entries as indexed keys
+  (`BookStack:ScopedBooks:0`, `BookStack:ScopedBooks:1`, …) so that `Configure<ScopeFilterOptions>`
+  binds them directly as list elements.
+- Slug comparison is case-insensitive (`StringComparison.OrdinalIgnoreCase`).
+- `BookStack:ScopedBooks` and `BookStack:ScopedShelves` are the configuration section keys, so
+  they bind to `ScopeFilterOptions.ScopedBooks` and `ScopeFilterOptions.ScopedShelves` via the
+  existing `GetSection("BookStack")` binding.
+
+## Rationale
+
+### Filter placement: MCP tool layer, not BookStack API
+
+BookStack's `/api/books` and `/api/shelves` endpoints have no filtering by shelf membership or
+arbitrary ID list. The search endpoint accepts `{filter:book_id=N}` for a **single** book ID only;
+supporting multiple IDs would require undocumented query construction that may silently fail.
+Slug-to-ID resolution (required for API-side filtering) would add extra HTTP round-trips at query
+time, increasing latency and coupling. Post-fetch filtering is simple, transparent, and consistent
+across all five affected handlers.
+
+The known trade-off — that `count`/`offset` pagination is applied by the API before scope
+filtering, so filtered pages may contain fewer items than requested — is documented in the spec as
+an acceptable limitation given expected scope sizes of 1–10 books per deployment.
+
+### DI registration: `IOptions<ScopeFilterOptions>` via `Configure<T>`
+
+This follows the existing pattern for `BookStackApiClientOptions` (registered in
+`AddBookStackApiClient`, bound from `configuration.GetSection("BookStack")`). Using `IOptions<T>`
+makes the options injectable with `Options.Create(new ScopeFilterOptions { ... })` in unit tests
+with no running host, which is the pattern already used in the test suite. A `Singleton` manual
+registration would require more boilerplate and would not integrate with the `IOptions` validation
+pipeline if validation is added in the future.
+
+### Filter logic: static helper, not service
+
+`ScopeFilter.MatchesScope` is a pure function with no state and no I/O. Registering it as a DI
+service would require an interface and a registration call for something that has no alternative
+implementation and never needs to be mocked. A `static internal` class is simpler and easier to
+test directly. The `ScopeFilter` class is co-located with `ScopeFilterOptions` in the `config/`
+folder to indicate it is configuration-layer infrastructure.
+
+### Env var parsing: indexed `IConfiguration` keys
+
+`IConfiguration.GetSection("BookStack").Bind(options)` only maps a list from indexed keys
+(`BookStack:ScopedBooks:0`, `BookStack:ScopedBooks:1`, …), not from a comma-separated string
+value. Splitting and indexing in `MapBookStackEnvVars()` keeps the conversion in one place and
+avoids a custom `IConfigurationProvider` or a post-`Bind` parsing step. This is the idiomatic
+approach for populating `IReadOnlyList<string>` from environment variables in the existing
+configuration architecture.
+
+### Input validation: reject-and-warn
+
+Scope entries are validated against `^[a-zA-Z0-9_-]+$` at parsing time in `MapBookStackEnvVars()`.
+This is the character set for BookStack slugs (lowercase alphanumeric plus hyphen) and positive
+integers. Rejecting entries that do not match this pattern prevents unexpected comparison behaviour
+and satisfies the OWASP A03 (Injection) requirement in the spec. Invalid entries are discarded
+with a `LogWarning` rather than a hard failure, so a misconfigured entry does not prevent the
+server from starting.
+
+## Alternatives Considered
+
+### Option A: Pass scope IDs as BookStack API query parameters
+
+- **Pros**: Server-side filtering; no data returned for out-of-scope items; accurate pagination.
+- **Cons**: Only single `book_id` filter supported; slugs require extra API round-trips; complex
+  query string construction for multiple IDs; behaviour may differ between BookStack versions.
+- **Why rejected**: The BookStack API does not expose the required filtering surface.
+
+### Option B: Dedicated `IScopeFilterService` DI service
+
+- **Pros**: Mockable in tests; extensible for future caching or async resolution of slugs to IDs.
+- **Cons**: No alternative implementation exists or is planned; injecting a no-op interface for a
+  pure function adds indirection without value; violates YAGNI.
+- **Why rejected**: `ScopeFilter` is a pure function with no testability advantage from a DI
+  interface.
+
+### Option C: Separate `AddScopeFilter()` extension method
+
+- **Pros**: Explicit separation from API client registration.
+- **Cons**: Requires a second DI call in `Program.cs`; all scope filtering is directly tied to the
+  BookStack API client configuration — they belong in the same registration.
+- **Why rejected**: Unnecessary split for a small co-dependent configuration.
+
+### Option D: Parse comma-separated string in `ScopeFilterOptions` setter
+
+- **Pros**: Keeps `MapBookStackEnvVars()` simple.
+- **Cons**: Business logic in a configuration class; the class would need a special-cased binding
+  path; `IReadOnlyList<string>` is not the right type for a string property.
+- **Why rejected**: Non-idiomatic; violates single-responsibility for a configuration model.
+
+## Consequences
+
+### Positive
+
+- No changes to `IBookStackApiClient`, `BookStackApiClient`, or any model.
+- `ScopeFilter` is directly unit-testable without DI setup.
+- Handler injection pattern is consistent across the five affected handlers.
+- `IOptions<ScopeFilterOptions>` integrates with existing test helper pattern (`Options.Create`).
+- Empty scope is a zero-cost path — the filter guard returns immediately, preserving the existing
+  default behaviour exactly.
+
+### Negative / Trade-offs
+
+- Pagination accuracy: `count`/`offset` apply to the unfiltered API result; filtered pages may be
+  smaller than requested. Documented in spec as a known limitation.
+- `SearchResult` filtering is by book association only — items without a `Book` property (e.g.,
+  shelf results in search) are excluded when `ScopedBooks` is set. Shelf-based search filtering is
+  deferred.
+- The five affected handlers each add one constructor parameter and two lines of filter code — a
+  small but real increase in handler complexity.
+
+## Related ADRs
+
+- [ADR-0005: IHttpClientFactory Typed Client](ADR-0005-ihttpclientfactory-typed-client.md)
+- [ADR-0009: Dual-Transport Entry-Point Strategy](ADR-0009-dual-transport-entry-point.md)

--- a/docs/features/book-shelf-scope-filtering/plan.md
+++ b/docs/features/book-shelf-scope-filtering/plan.md
@@ -1,0 +1,279 @@
+# Plan: Book/Shelf Scope Filtering (FEAT-0054)
+
+**Feature**: Book/Shelf Scope Filtering
+**Spec**: [docs/features/book-shelf-scope-filtering/spec.md](spec.md)
+**GitHub Issue**: [#54](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/54)
+**Status**: Ready for Implementation
+**Date**: 2026-04-25
+
+---
+
+## Referenced ADRs
+
+| ADR | Title | Decision |
+|-----|-------|----------|
+| [ADR-0014](../../architecture/decisions/ADR-0014-scope-filter-architecture.md) | Scope Filter Architecture | Post-fetch filtering at MCP tool layer; `IOptions<ScopeFilterOptions>`; static `ScopeFilter` helper; indexed config keys |
+
+---
+
+## Data Model Changes
+
+No database tables, EF Core migrations, or `IBookStackApiClient` interface changes. New types are
+configuration-layer only.
+
+### New: `ScopeFilterOptions`
+
+```csharp
+// src/BookStack.Mcp.Server/config/ScopeFilterOptions.cs
+namespace BookStack.Mcp.Server.Config;
+
+public sealed class ScopeFilterOptions
+{
+    public IReadOnlyList<string> ScopedShelves { get; set; } = [];
+    public IReadOnlyList<string> ScopedBooks   { get; set; } = [];
+
+    public bool HasBookScope  => ScopedBooks.Count   > 0;
+    public bool HasShelfScope => ScopedShelves.Count > 0;
+}
+```
+
+### New: `ScopeFilter` (static helper)
+
+```csharp
+// src/BookStack.Mcp.Server/config/ScopeFilter.cs
+namespace BookStack.Mcp.Server.Config;
+
+internal static class ScopeFilter
+{
+    internal static bool MatchesScope(int id, string slug, IReadOnlyList<string> scope)
+    {
+        foreach (var entry in scope)
+        {
+            if (int.TryParse(entry, out var scopeId) && scopeId == id)
+                return true;
+            if (string.Equals(entry, slug, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+}
+```
+
+---
+
+## Configuration: Env Var Mapping
+
+`MapBookStackEnvVars()` in `Program.cs` is extended. Each env var value is split on commas,
+trimmed, regex-validated (`^[a-zA-Z0-9_-]+$`), and written as indexed `IConfiguration` keys:
+
+```csharp
+static void AddScopeEntries(
+    Dictionary<string, string?> map,
+    string envVar,
+    string configPrefix,
+    ILogger? logger = null)
+{
+    var raw = Environment.GetEnvironmentVariable(envVar);
+    if (raw is null) return;
+
+    var valid = raw.Split(',')
+        .Select(e => e.Trim())
+        .Where(e => e.Length > 0)
+        .ToList();
+
+    var pattern = new Regex(@"^[a-zA-Z0-9_-]+$");
+    var index = 0;
+    foreach (var entry in valid)
+    {
+        if (!pattern.IsMatch(entry))
+        {
+            // Log warning: entry discarded
+            continue;
+        }
+        map[$"{configPrefix}:{index++}"] = entry;
+    }
+}
+```
+
+Called twice inside `MapBookStackEnvVars()`:
+
+```csharp
+AddScopeEntries(map, "BOOKSTACK_SCOPED_BOOKS",   "BookStack:ScopedBooks");
+AddScopeEntries(map, "BOOKSTACK_SCOPED_SHELVES", "BookStack:ScopedShelves");
+```
+
+`AddBookStackApiClient` registers:
+
+```csharp
+services.Configure<ScopeFilterOptions>(configuration.GetSection("BookStack"));
+```
+
+---
+
+## Affected Handlers
+
+| Handler | File | Scope | Change |
+|---------|------|-------|--------|
+| `BookToolHandler` | `tools/books/BookToolHandler.cs` | `ScopedBooks` | `ListBooksAsync` — inject `IOptions<ScopeFilterOptions>`, filter after API call |
+| `ShelfToolHandler` | `tools/shelves/ShelfToolHandler.cs` | `ScopedShelves` | `ListShelvesAsync` — inject, filter |
+| `SearchToolHandler` | `tools/search/SearchToolHandler.cs` | `ScopedBooks` | `SearchAsync` — inject, filter `SearchResultItem` by `Book.Id/Slug` or item `Id/Slug` when `Type == "book"` |
+| `BookResourceHandler` | `resources/books/BookResourceHandler.cs` | `ScopedBooks` | `GetBooksAsync` — inject, filter |
+| `ShelfResourceHandler` | `resources/shelves/ShelfResourceHandler.cs` | `ScopedShelves` | `GetShelvesAsync` — inject, filter |
+
+### Filter pattern in `ListBooksAsync` (representative)
+
+```csharp
+var result = await _client.ListBooksAsync(query, ct).ConfigureAwait(false);
+
+var scope = _scopeOptions.Value;
+if (scope.HasBookScope)
+{
+    var filtered = result.Data
+        .Where(b => ScopeFilter.MatchesScope(b.Id, b.Slug, scope.ScopedBooks))
+        .ToList();
+    result = new ListResponse<Book>
+    {
+        Total = filtered.Count,
+        From  = result.From,
+        To    = result.To,
+        Data  = filtered,
+    };
+}
+```
+
+### Filter pattern in `SearchAsync`
+
+```csharp
+if (scope.HasBookScope)
+{
+    var filtered = result.Data.Where(item =>
+        item.Type == "book"
+            ? ScopeFilter.MatchesScope(item.Id, item.Slug, scope.ScopedBooks)
+            : item.Book is not null && ScopeFilter.MatchesScope(
+                  item.Book.Id, item.Book.Slug, scope.ScopedBooks))
+        .ToList();
+    result = new SearchResult
+    {
+        Total = filtered.Count,
+        From  = result.From,
+        To    = result.To,
+        Data  = filtered,
+    };
+}
+```
+
+---
+
+## VS Code Extension Changes
+
+File: `vscode-extension/package.json` — new entries in `contributes.configuration.properties`:
+
+```json
+"bookstack.scopedShelves": {
+  "type": "string",
+  "default": "",
+  "markdownDescription": "Comma-separated shelf IDs or slugs to restrict MCP tools to specific shelves. Leave blank for all shelves."
+},
+"bookstack.scopedBooks": {
+  "type": "string",
+  "default": "",
+  "markdownDescription": "Comma-separated book IDs or slugs to restrict MCP tools to specific books. Leave blank for all books."
+}
+```
+
+File: `vscode-extension/src/` — wherever the MCP server spawn env vars are built, add:
+
+```typescript
+BOOKSTACK_SCOPED_SHELVES: config.get<string>('bookstack.scopedShelves', ''),
+BOOKSTACK_SCOPED_BOOKS:   config.get<string>('bookstack.scopedBooks',   ''),
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Config and DI
+
+| Task | File | Description |
+|------|------|-------------|
+| T1 | `config/ScopeFilterOptions.cs` | Create `ScopeFilterOptions` class |
+| T2 | `config/ScopeFilter.cs` | Create static `ScopeFilter` helper |
+| T3 | `Program.cs` | Extend `MapBookStackEnvVars()` with scope env var parsing and regex validation |
+| T4 | `api/BookStackServiceCollectionExtensions.cs` | Add `services.Configure<ScopeFilterOptions>(configuration.GetSection("BookStack"))` |
+
+### Phase 2 — Tool Handler Updates
+
+| Task | File | Description |
+|------|------|-------------|
+| T5 | `tools/books/BookToolHandler.cs` | Inject `IOptions<ScopeFilterOptions>`; apply book filter in `ListBooksAsync` |
+| T6 | `tools/shelves/ShelfToolHandler.cs` | Inject; apply shelf filter in `ListShelvesAsync` |
+| T7 | `tools/search/SearchToolHandler.cs` | Inject; apply book filter to `SearchResult.Data` in `SearchAsync` |
+
+### Phase 3 — Resource Handler Updates
+
+| Task | File | Description |
+|------|------|-------------|
+| T8 | `resources/books/BookResourceHandler.cs` | Inject; apply book filter in `GetBooksAsync` |
+| T9 | `resources/shelves/ShelfResourceHandler.cs` | Inject; apply shelf filter in `GetShelvesAsync` |
+
+### Phase 4 — VS Code Extension
+
+| Task | File | Description |
+|------|------|-------------|
+| T10 | `vscode-extension/package.json` | Add `bookstack.scopedShelves` and `bookstack.scopedBooks` settings |
+| T11 | `vscode-extension/src/<spawn-provider>` | Map settings to `BOOKSTACK_SCOPED_BOOKS` / `BOOKSTACK_SCOPED_SHELVES` env vars |
+
+### Phase 5 — Tests
+
+| Task | Description | Coverage |
+|------|-------------|----------|
+| T12 | `ScopeFilterTests.cs` | `MatchesScope` with numeric ID, slug (case-insensitive), empty scope, no match |
+| T13 | `BookToolHandlerTests.cs` | `ListBooksAsync` scoped/unscoped; `Total` update; read tool unaffected |
+| T14 | `ShelfToolHandlerTests.cs` | `ListShelvesAsync` scoped/unscoped |
+| T15 | `SearchToolHandlerTests.cs` | `SearchAsync` filters by book; items without book reference excluded |
+| T16 | `ProgramTests.cs` / `MapBookStackEnvVarsTests.cs` | Valid entries, whitespace trim, invalid entry discarded with warning |
+| T17 | `BookResourceHandlerTests.cs` | `GetBooksAsync` scoped |
+| T18 | `ShelfResourceHandlerTests.cs` | `GetShelvesAsync` scoped |
+
+---
+
+## Commands
+
+### Build
+
+```
+dotnet build /home/mark/github/bookstack-mcp-server-dotnet/BookStack.Mcp.Server.sln --configuration Release
+```
+
+### Tests
+
+```
+dotnet test /home/mark/github/bookstack-mcp-server-dotnet/BookStack.Mcp.Server.sln --verbosity normal
+```
+
+### Lint / Formatting
+
+```
+dotnet format /home/mark/github/bookstack-mcp-server-dotnet/BookStack.Mcp.Server.sln --verify-no-changes
+```
+
+### Local Run (stdio)
+
+```
+dotnet run --project /home/mark/github/bookstack-mcp-server-dotnet/src/BookStack.Mcp.Server
+```
+
+---
+
+## Key Constraints
+
+- No changes to `IBookStackApiClient` or any model class.
+- `ListResponse<T>` replacement must set `Total = filtered.Count`; `From`/`To` are left as-is
+  (they reflect the raw API pagination offset, not the filtered window).
+- `SearchResult` (not `ListResponse`) is the return type of `SearchAsync` — requires a parallel
+  filter path.
+- Empty scope (`HasBookScope == false` / `HasShelfScope == false`) MUST bypass all filter code —
+  verified by CC-03 acceptance criterion.
+- Slug comparison: `StringComparison.OrdinalIgnoreCase`.
+- Entry validation regex: `^[a-zA-Z0-9_-]+$` — applied in `MapBookStackEnvVars()`, not in
+  `ScopeFilter.MatchesScope` (entries in `ScopeFilterOptions` are already validated).

--- a/docs/features/book-shelf-scope-filtering/spec.md
+++ b/docs/features/book-shelf-scope-filtering/spec.md
@@ -1,0 +1,380 @@
+# Feature Spec: Book/Shelf Scope Filtering for MCP Tools
+
+**ID**: FEAT-0054
+**Status**: Draft
+**Author**: GitHub Copilot
+**Created**: 2026-04-25
+**Last Updated**: 2026-04-25
+**GitHub Issue**: [#54 — Book/Shelf Scope Filtering for MCP Tools](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/54)
+**Parent Epic**: [#1 — Core MCP Server](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/1)
+**Related ADRs**: None yet — see Technical Decisions Identified.
+
+---
+
+## Executive Summary
+
+- **Objective**: Allow operators and end-users to restrict which books and shelves the MCP tools and
+  resource handlers operate against, so AI agents only surface content from a configured subset of
+  the BookStack instance.
+- **Primary user**: Operators deploying the server for a team or project who want to limit AI agent
+  access to a relevant slice of content; VS Code users who configure their scoped workspace via the
+  extension.
+- **Value delivered**: Prevents AI agents from surfacing irrelevant or sensitive content from
+  unrelated books/shelves, reduces noise in AI responses, and enables per-project MCP server
+  deployments without separate BookStack instances.
+- **Scope**: New `ScopeFilterOptions` configuration class, `MapBookStackEnvVars()` extension,
+  application-layer post-fetch filtering in `bookstack_books_list`, `bookstack_shelves_list`,
+  `bookstack_search`, and all list resource handlers. VS Code extension new settings
+  `bookstack.scopedShelves` and `bookstack.scopedBooks` mapped to env vars. No changes to
+  single-item-by-ID tools, the `IBookStackApiClient` interface, the BookStack API call parameters,
+  or the data layer.
+- **Primary success criterion**: When scope is configured, list and search results contain only
+  items belonging to the configured books/shelves; when scope is empty, behaviour is identical to
+  today.
+
+---
+
+## Problem Statement
+
+The BookStack MCP server currently exposes the full set of books, shelves, and search results
+visible to the authenticated API token. In shared BookStack instances with many books, AI agents
+receive overwhelming or irrelevant results and may surface content that belongs to unrelated teams
+or projects. There is no mechanism to restrict the server to a relevant subset of content without
+creating a separate BookStack API token with restricted permissions — which requires BookStack
+admin access and per-shelf permission configuration.
+
+Operators need a lightweight, configuration-driven way to pin the MCP server to one or more
+specific books or shelves without modifying BookStack's permission model.
+
+## Goals
+
+1. Provide two environment variables (`BOOKSTACK_SCOPED_SHELVES`, `BOOKSTACK_SCOPED_BOOKS`) that
+   accept comma-separated book/shelf identifiers (numeric IDs or slugs) and restrict list and
+   search results to the configured subset.
+2. Apply scope filtering at the MCP tool layer so that `bookstack_books_list`,
+   `bookstack_shelves_list`, `bookstack_search`, and all MCP resource list handlers return only
+   in-scope items when a scope is configured.
+3. Expose `bookstack.scopedShelves` and `bookstack.scopedBooks` settings in the VS Code extension
+   so users can configure scope through the VS Code Settings UI without editing environment
+   variables manually.
+4. Leave single-item-by-ID tools (`bookstack_books_read`, `bookstack_pages_read`, etc.) completely
+   unaffected by scope — they always pass through to the BookStack API.
+5. Preserve the existing default behaviour (empty scope = all content) so no currently deployed
+   configuration requires changes.
+
+## Non-Goals
+
+- Modifying the `IBookStackApiClient` interface or any `BookStackApiClient` implementation method.
+- Passing scope IDs as query parameters to the BookStack REST API — filtering is applied
+  application-side after the API response is received.
+- Implementing scope filtering for semantic / vector search (feature #11) — see Out of Scope.
+- Per-user or per-role scope — this is a single operator-level configuration.
+- Dynamic scope changes without restarting the server process.
+- Slug-to-ID resolution at startup — slugs and IDs are matched directly against the `Slug` and `Id`
+  fields of each returned item, requiring no extra API calls.
+
+## Requirements
+
+### Functional Requirements
+
+1. The system MUST read `BOOKSTACK_SCOPED_SHELVES` from the environment as a comma-separated list
+   of shelf identifiers (integer IDs and/or slugs). Leading and trailing whitespace around each
+   entry MUST be trimmed.
+2. The system MUST read `BOOKSTACK_SCOPED_BOOKS` from the environment as a comma-separated list of
+   book identifiers (integer IDs and/or slugs), with the same trimming rule.
+3. A new `ScopeFilterOptions` configuration class MUST be introduced in the
+   `BookStack.Mcp.Server.Config` namespace and registered via `IOptions<ScopeFilterOptions>`. It
+   MUST expose:
+   - `IReadOnlyList<string> ScopedShelves` — parsed from `BookStack:ScopedShelves`
+   - `IReadOnlyList<string> ScopedBooks` — parsed from `BookStack:ScopedBooks`
+4. `MapBookStackEnvVars()` in `Program.cs` MUST be extended to map:
+   - `BOOKSTACK_SCOPED_SHELVES` → `BookStack:ScopedShelves`
+   - `BOOKSTACK_SCOPED_BOOKS` → `BookStack:ScopedBooks`
+5. When `ScopedBooks` is non-empty, `bookstack_books_list` MUST return only books whose `Id` (when
+   the entry is numeric) or `Slug` (when the entry is non-numeric) matches any entry in
+   `ScopedBooks`. Non-matching books MUST be omitted from the result.
+6. When `ScopedShelves` is non-empty, `bookstack_shelves_list` MUST return only shelves whose `Id`
+   or `Slug` matches any entry in `ScopedShelves`. Non-matching shelves MUST be omitted.
+7. When `ScopedBooks` is non-empty, `bookstack_search` MUST post-filter results: any
+   `SearchResultItem` where the associated `Book.Id` or `Book.Slug` does not match any entry in
+   `ScopedBooks` MUST be omitted. Items whose `Type` is `book` are matched directly on their own
+   `Id`/`Slug`. Items of type `shelf`, `chapter`, or `page` without a resolvable book association
+   MUST also be omitted when `ScopedBooks` is configured.
+8. The `bookstack://books` MCP resource handler MUST apply the same book scope filter as
+   requirement 5.
+9. The `bookstack://shelves` MCP resource handler MUST apply the same shelf scope filter as
+   requirement 6.
+10. When scope is empty (both env vars absent or blank), all filtering logic MUST be bypassed and
+    the full API response MUST be returned unchanged — this is the existing default behaviour.
+11. The `Total` field in paginated responses returned by list tools MUST reflect the count of
+    items after scope filtering, not the raw total from the BookStack API.
+12. Single-item-by-ID tools (`bookstack_books_read`, `bookstack_shelves_read`,
+    `bookstack_chapters_read`, `bookstack_pages_read`, etc.) MUST NOT apply any scope filtering.
+13. The VS Code extension MUST expose two new settings:
+    - `bookstack.scopedShelves` — `string`, default `""`, description: comma-separated shelf IDs
+      or slugs.
+    - `bookstack.scopedBooks` — `string`, default `""`, description: comma-separated book IDs or
+      slugs.
+    These settings MUST be passed as `BOOKSTACK_SCOPED_SHELVES` and `BOOKSTACK_SCOPED_BOOKS`
+    environment variables when the extension launches the MCP server process.
+
+### Non-Functional Requirements
+
+1. Scope filtering MUST add no additional HTTP requests to the BookStack API; all filtering is
+   applied to data already retrieved by the existing API call.
+2. `ScopeFilterOptions` MUST be injected via `IOptions<ScopeFilterOptions>` so that it is
+   testable with `Options.Create(...)` in unit tests without a running server.
+3. All filter logic MUST be covered by unit tests in `BookStack.Mcp.Server.Tests` using TUnit
+   and mocked `IBookStackApiClient`.
+4. Scope identifiers MUST be compared case-insensitively for slug values (BookStack slugs are
+   lowercase but user input may vary).
+5. The feature MUST not introduce any breaking changes to existing MCP tool names, parameters, or
+   response schemas.
+
+## Design
+
+### Open Questions Resolution
+
+The three open questions from issue #54 are resolved as follows:
+
+**Q1 — Filter at MCP tool layer vs pass IDs as query params to BookStack API?**
+
+**Decision: MCP tool layer (application-side post-fetch filtering).**
+
+Rationale: BookStack's list endpoints (`/api/books`, `/api/shelves`) do not support filtering by
+shelf membership or arbitrary ID lists. BookStack's search endpoint supports `{filter:book_id=N}`
+syntax in the query string, but only for a single book ID; injecting multiple IDs would require
+constructing complex query syntax that is undocumented and may be silently ignored. Slug-to-ID
+resolution (needed to use server-side filters) would require extra API calls, adding latency and
+complexity. Post-fetch filtering is simpler, transparent, and consistent across all affected
+endpoints. The trade-off — that pagination `count`/`offset` parameters are applied to the
+unfiltered set before filtering — is documented as a known limitation and is acceptable for the
+expected scope sizes (typically 1–10 books/shelves per deployment).
+
+**Q2 — Server-side (env vars) or client-side (VS Code settings) enforcement?**
+
+**Decision: Server-side enforcement via env vars; VS Code settings are mapped to env vars by
+the extension.**
+
+Rationale: Filtering at the server is the authoritative enforcement point regardless of the MCP
+client in use (VS Code, Claude Desktop, CI pipelines, etc.). VS Code settings provide a
+user-friendly configuration surface that the extension converts to env vars when launching the
+server process — the same pattern already used for `bookstack.url` and token settings. The server
+is the single source of truth; the VS Code extension is a configuration façade.
+
+**Q3 — How does scoping interact with semantic search (feature #11)?**
+
+**Decision: Deferred to feature #11. This feature makes no provision for semantic/vector search.**
+
+Rationale: Feature #11 (vector search / pgvector) has not begun implementation. When it is
+designed, `ScopeFilterOptions` will be injected into the semantic search handler, which will
+apply book scope to candidate set retrieval (either as a pre-filter on indexed book IDs or as a
+post-filter on the ranked result set). Feature #11's spec must reference this spec and explicitly
+enumerate how `ScopedBooks` and `ScopedShelves` apply to vector queries. No assumptions are
+encoded in this feature.
+
+---
+
+### Component Diagram
+
+```mermaid
+graph TD
+    A[MCP Client] --> B[Tool / Resource Handler]
+    B --> C[IBookStackApiClient]
+    C --> D[BookStack API]
+    D -->|Full result set| C
+    C -->|Full result set| B
+    B --> E[ScopeFilter.Apply]
+    E -->|Filtered result set| A
+    F[IOptions<ScopeFilterOptions>] --> E
+    G[BOOKSTACK_SCOPED_BOOKS\nBOOKSTACK_SCOPED_SHELVES] -->|MapBookStackEnvVars| H[IConfiguration]
+    H --> F
+```
+
+### Data Flow: Scoped Book List
+
+```mermaid
+sequenceDiagram
+    participant Client as MCP Client
+    participant Tool as BookToolHandler
+    participant Api as IBookStackApiClient
+    participant Filter as ScopeFilter
+    participant BS as BookStack API
+
+    Client->>Tool: bookstack_books_list(count, offset)
+    Tool->>Api: ListBooksAsync(query)
+    Api->>BS: GET /api/books?count=N&offset=M
+    BS-->>Api: { total: T, data: [...all books...] }
+    Api-->>Tool: ListResponse<Book>
+    Tool->>Filter: Apply(books, ScopedBooks)
+    Filter-->>Tool: filtered books
+    Tool-->>Client: JSON { total: filtered_count, data: [...scoped books...] }
+```
+
+### New Configuration Class
+
+```csharp
+// src/BookStack.Mcp.Server/config/ScopeFilterOptions.cs
+namespace BookStack.Mcp.Server.Config;
+
+public sealed class ScopeFilterOptions
+{
+    public IReadOnlyList<string> ScopedShelves { get; set; } = [];
+    public IReadOnlyList<string> ScopedBooks   { get; set; } = [];
+
+    public bool HasBookScope   => ScopedBooks.Count   > 0;
+    public bool HasShelfScope  => ScopedShelves.Count > 0;
+}
+```
+
+### Env Var Mapping Extension
+
+```csharp
+// Addition to MapBookStackEnvVars() in Program.cs
+var scopedShelves = Environment.GetEnvironmentVariable("BOOKSTACK_SCOPED_SHELVES");
+if (scopedShelves is not null)
+    map["BookStack:ScopedShelves"] = scopedShelves;
+
+var scopedBooks = Environment.GetEnvironmentVariable("BOOKSTACK_SCOPED_BOOKS");
+if (scopedBooks is not null)
+    map["BookStack:ScopedBooks"] = scopedBooks;
+```
+
+> **Note**: `IConfiguration` binding for a `IReadOnlyList<string>` from a comma-separated value
+> requires either a custom converter or splitting the string before passing to `AddInMemoryCollection`.
+> The recommended approach is to split on comma in `MapBookStackEnvVars()` and populate indexed keys
+> (`BookStack:ScopedBooks:0`, `BookStack:ScopedBooks:1`, …`) so that `Configure<ScopeFilterOptions>`
+> binds directly.
+
+### Filter Helper
+
+```csharp
+// Suggested placement: src/BookStack.Mcp.Server/config/ScopeFilter.cs
+internal static class ScopeFilter
+{
+    internal static bool MatchesScope(int id, string slug, IReadOnlyList<string> scope)
+    {
+        foreach (var entry in scope)
+        {
+            if (int.TryParse(entry, out var scopeId) && scopeId == id)
+                return true;
+            if (string.Equals(entry, slug, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+}
+```
+
+### Affected Tool and Resource Handlers
+
+| Handler | Method | Scope Applied | Filter Field |
+| ------- | ------ | ------------- | ------------ |
+| `BookToolHandler` | `ListBooksAsync` | `ScopedBooks` | `Book.Id` / `Book.Slug` |
+| `ShelfToolHandler` | `ListShelvesAsync` | `ScopedShelves` | `Bookshelf.Id` / `Bookshelf.Slug` |
+| `SearchToolHandler` | `SearchAsync` | `ScopedBooks` | `SearchResultItem.Book.Id/.Slug` or item `Id`/`Slug` when `Type == "book"` |
+| `BookResourceHandler` | `GetBooksAsync` (resource) | `ScopedBooks` | `Book.Id` / `Book.Slug` |
+| `ShelfResourceHandler` | `GetShelvesAsync` (resource) | `ScopedShelves` | `Bookshelf.Id` / `Bookshelf.Slug` |
+
+### VS Code Extension Settings
+
+New entries in `package.json` `contributes.configuration.properties`:
+
+```json
+"bookstack.scopedShelves": {
+  "type": "string",
+  "default": "",
+  "markdownDescription": "Comma-separated shelf IDs or slugs to restrict MCP tools to specific shelves. Leave blank for all shelves."
+},
+"bookstack.scopedBooks": {
+  "type": "string",
+  "default": "",
+  "markdownDescription": "Comma-separated book IDs or slugs to restrict MCP tools to specific books. Leave blank for all books."
+}
+```
+
+The extension's MCP server definition provider MUST pass these as env vars when constructing the
+server spawn configuration:
+
+```typescript
+env: {
+  BOOKSTACK_BASE_URL:       config.get<string>('bookstack.url', ''),
+  BOOKSTACK_TOKEN_SECRET:   `${tokenId}:${tokenSecret}`,
+  BOOKSTACK_SCOPED_SHELVES: config.get<string>('bookstack.scopedShelves', ''),
+  BOOKSTACK_SCOPED_BOOKS:   config.get<string>('bookstack.scopedBooks', ''),
+}
+```
+
+## Acceptance Criteria
+
+- [ ] Given `BOOKSTACK_SCOPED_BOOKS` is unset, when `bookstack_books_list` is called, then all
+  books returned by the BookStack API are included in the response.
+- [ ] Given `BOOKSTACK_SCOPED_BOOKS=42`, when `bookstack_books_list` is called and the API returns
+  books with IDs 42, 99, and 7, then only the book with ID 42 is present in the response.
+- [ ] Given `BOOKSTACK_SCOPED_BOOKS=my-team-guide`, when `bookstack_books_list` is called and the
+  API returns a book with slug `my-team-guide` and other books, then only the book with slug
+  `my-team-guide` is returned (case-insensitive match).
+- [ ] Given `BOOKSTACK_SCOPED_BOOKS=42,my-team-guide`, when `bookstack_books_list` is called,
+  then books matching ID 42 OR slug `my-team-guide` are both returned.
+- [ ] Given `BOOKSTACK_SCOPED_SHELVES=5`, when `bookstack_shelves_list` is called and the API
+  returns shelf 5 and shelf 9, then only shelf 5 is present in the response.
+- [ ] Given `BOOKSTACK_SCOPED_BOOKS=42`, when `bookstack_search` is called with query `"meeting
+  notes"`, then search results whose associated book ID is not 42 are omitted from the response.
+- [ ] Given `BOOKSTACK_SCOPED_BOOKS=42`, when `bookstack_books_read` is called with `id=99`, then
+  the full book 99 is returned without any scope filtering.
+- [ ] Given `BOOKSTACK_SCOPED_BOOKS=42`, when the `bookstack://books` resource is read, then only
+  books matching ID 42 are included.
+- [ ] Given `BOOKSTACK_SCOPED_BOOKS= 42 , my-guide ` (entries with whitespace), when the server
+  starts, then entries are trimmed to `42` and `my-guide`.
+- [ ] Given VS Code settings `bookstack.scopedBooks = "42"`, when the extension launches the MCP
+  server, then the process receives `BOOKSTACK_SCOPED_BOOKS=42` as an environment variable.
+- [ ] Given `BOOKSTACK_SCOPED_BOOKS=42`, when `bookstack_books_list` returns 3 matching books from
+  a raw API result of 10, then the `total` field in the response is 3.
+
+## Compliance Criteria
+
+| ID | Scenario | Input / Condition | Expected Output |
+|----|----------|-------------------|-----------------|
+| CC-01 | Scope matches by ID | `BOOKSTACK_SCOPED_BOOKS=42`; API returns books [42, 7, 99] | Response contains only book 42; `total = 1` |
+| CC-02 | Scope matches by slug (case-insensitive) | `BOOKSTACK_SCOPED_BOOKS=My-Team-Guide`; API returns book with slug `my-team-guide` and book with slug `other` | Response contains only the `my-team-guide` book |
+| CC-03 | Empty scope — no filtering | `BOOKSTACK_SCOPED_BOOKS` unset; API returns 5 books | Response contains all 5 books unchanged |
+| CC-04 | Scope configured but no match | `BOOKSTACK_SCOPED_BOOKS=999`; API returns books [1, 2, 3] | Response contains zero books; `total = 0` |
+| CC-05 | Single-item tool bypasses scope | `BOOKSTACK_SCOPED_BOOKS=42`; `bookstack_books_read(id=7)` called | Book 7 returned in full with no filtering |
+| CC-06 | Search result filtered | `BOOKSTACK_SCOPED_BOOKS=42`; search returns 3 items: book 42, page in book 10, page in book 42 | Response contains 2 items (book 42 and page in book 42); item in book 10 omitted |
+| CC-07 | Must NOT — scope leaks to read tool | `BOOKSTACK_SCOPED_BOOKS=42`; any `*_read` or `*_create` tool called | No filtering applied; full API response returned |
+| CC-08 | Whitespace trimming | `BOOKSTACK_SCOPED_BOOKS=" 42 , my-guide "` | Parsed as IDs/slugs `["42", "my-guide"]` |
+| CC-09 | Mixed IDs and slugs | `BOOKSTACK_SCOPED_BOOKS=42,roadmap` | Books with ID 42 OR slug `roadmap` are included |
+
+## Security Considerations
+
+- `BOOKSTACK_SCOPED_SHELVES` and `BOOKSTACK_SCOPED_BOOKS` contain only IDs and slugs — no
+  credentials or secrets. They MAY be logged at the information level on startup to aid
+  diagnostics.
+- Scope filtering is an access-narrowing control, not an access-granting control. A user who can
+  call `bookstack_books_read` with an arbitrary ID can still read any book the API token permits.
+  Operators who require true access restriction must configure BookStack's own permission model.
+- Input validation: each scope entry MUST be validated to contain only alphanumeric characters,
+  hyphens, and underscores (the valid character set for BookStack slugs and positive integers). Any
+  entry that does not match this pattern MUST be rejected at startup with a logged warning and the
+  entry MUST be discarded to prevent injection into comparison logic (OWASP A03 — Injection).
+
+## Known Limitations
+
+- **Pagination accuracy**: `count` and `offset` parameters are applied by the BookStack API before
+  scope filtering. If a caller requests `count=10, offset=0` and only 2 of the returned 10 books
+  are in scope, the filtered response contains 2 items. Callers iterating with pagination should
+  use a large `count` value or iterate until no results are returned. This is documented in the
+  tool description strings.
+- **Search scope is book-only**: Shelf scope does not apply to `bookstack_search` because
+  `SearchResultItem` carries a book reference but not a direct shelf reference. Restricting search
+  by shelf would require fetching shelf membership for each result — deferred to a future
+  enhancement.
+
+## Out of Scope
+
+- Semantic / vector search integration (feature #11) — feature #11 must consume `ScopeFilterOptions`
+  when implemented.
+- Dynamic scope changes at runtime without restarting the server process.
+- Per-user or per-role scope configuration.
+- Using BookStack API-side query filters (e.g., `{filter:book_id=N}`) as the filtering mechanism.
+- Search result filtering by shelf scope.

--- a/docs/features/book-shelf-scope-filtering/tasks.md
+++ b/docs/features/book-shelf-scope-filtering/tasks.md
@@ -1,0 +1,79 @@
+# Tasks: Book/Shelf Scope Filtering (FEAT-0054)
+
+**Feature**: Book/Shelf Scope Filtering
+**Parent Issue**: [#54](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/54)
+**Branch**: `feat/54-scope-filtering`
+**Spec**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+**ADR**: [ADR-0014](../../architecture/decisions/ADR-0014-scope-filter-architecture.md)
+
+---
+
+## Phase 1 — Config & DI
+
+**Issue**: [#73 — feat(#54): Config & DI — ScopeFilterOptions, ScopeFilter helper, env var mapping](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/73)
+
+- [ ] T1 — Create `ScopeFilterOptions` class in `src/BookStack.Mcp.Server/config/ScopeFilterOptions.cs`
+- [ ] T2 — Create static `ScopeFilter` helper in `src/BookStack.Mcp.Server/config/ScopeFilter.cs`
+- [ ] T3 — Extend `MapBookStackEnvVars()` in `src/BookStack.Mcp.Server/Program.cs` with scope env var parsing and regex validation
+- [ ] T4 — Register `IOptions<ScopeFilterOptions>` in `src/BookStack.Mcp.Server/api/BookStackServiceCollectionExtensions.cs`
+
+---
+
+## Phase 2 — Tool Handler Filtering
+
+**Issue**: [#74 — feat(#54): Tool handler filtering — books, shelves, search](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/74)
+**Depends on**: #73
+
+- [ ] T5 — Inject `IOptions<ScopeFilterOptions>` and apply book filter in `src/BookStack.Mcp.Server/tools/books/BookToolHandler.cs`
+- [ ] T6 — Inject and apply shelf filter in `src/BookStack.Mcp.Server/tools/shelves/ShelfToolHandler.cs`
+- [ ] T7 — Inject and apply book filter to `SearchResult.Data` in `src/BookStack.Mcp.Server/tools/search/SearchToolHandler.cs`
+
+---
+
+## Phase 3 — Resource Handler Filtering
+
+**Issue**: [#75 — feat(#54): Resource handler filtering — books and shelves resources](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/75)
+**Depends on**: #73 (parallel with #74)
+
+- [ ] T8 — Inject and apply book filter in `src/BookStack.Mcp.Server/resources/books/BookResourceHandler.cs`
+- [ ] T9 — Inject and apply shelf filter in `src/BookStack.Mcp.Server/resources/shelves/ShelfResourceHandler.cs`
+
+---
+
+## Phase 4 — VS Code Extension
+
+**Issue**: [#76 — feat(#54): VS Code extension — scopedBooks and scopedShelves settings](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/76)
+**Independent** (no code dependency on Phases 1–3)
+
+- [ ] T10 — Add `bookstack.scopedShelves` and `bookstack.scopedBooks` settings to `vscode-extension/package.json`
+- [ ] T11 — Map settings to `BOOKSTACK_SCOPED_BOOKS` / `BOOKSTACK_SCOPED_SHELVES` env vars in `vscode-extension/src/<spawn-provider>`
+
+---
+
+## Phase 5 — Tests
+
+**Issue**: [#77 — feat(#54): Tests — unit and integration tests for scope filtering](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/77)
+**Depends on**: #73, #74, #75
+
+- [ ] T12 — `tests/BookStack.Mcp.Server.Tests/config/ScopeFilterTests.cs` — `MatchesScope` unit tests (numeric ID, slug case-insensitive, empty scope, no match)
+- [ ] T13 — `tests/BookStack.Mcp.Server.Tests/tools/BookToolHandlerTests.cs` — scoped/unscoped list, `Total` update, read tool unaffected
+- [ ] T14 — `tests/BookStack.Mcp.Server.Tests/tools/ShelfToolHandlerTests.cs` — scoped/unscoped list
+- [ ] T15 — `tests/BookStack.Mcp.Server.Tests/tools/SearchToolHandlerTests.cs` — book-type items, items with/without book ref, unscoped pass-through
+- [ ] T16 — `tests/BookStack.Mcp.Server.Tests/config/MapBookStackEnvVarsTests.cs` — valid entries, whitespace trim, invalid entry discarded
+- [ ] T17 — `tests/BookStack.Mcp.Server.Tests/resources/BookResourceHandlerTests.cs` — scoped `GetBooksAsync`
+- [ ] T18 — `tests/BookStack.Mcp.Server.Tests/resources/ShelfResourceHandlerTests.cs` — scoped `GetShelvesAsync`
+
+---
+
+## Summary
+
+| Phase | Issue | Tasks | Status |
+|-------|-------|-------|--------|
+| 1 — Config & DI | [#73](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/73) | T1–T4 | open |
+| 2 — Tool handlers | [#74](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/74) | T5–T7 | open |
+| 3 — Resource handlers | [#75](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/75) | T8–T9 | open |
+| 4 — VS Code extension | [#76](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/76) | T10–T11 | open |
+| 5 — Tests | [#77](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/77) | T12–T18 | open |
+
+**Total tasks**: 18 across 5 issues
+**Dependency graph**: #73 → {#74, #75} → #77 · #76 (independent)

--- a/src/BookStack.Mcp.Server/Program.cs
+++ b/src/BookStack.Mcp.Server/Program.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 using BookStack.Mcp.Server.Api;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -141,7 +142,27 @@ static Dictionary<string, string?> MapBookStackEnvVars()
         }
     }
 
+    AddScopeEntries(map, "BOOKSTACK_SCOPED_BOOKS",   "BookStack:ScopedBooks");
+    AddScopeEntries(map, "BOOKSTACK_SCOPED_SHELVES", "BookStack:ScopedShelves");
+
     return map;
 }
 
-public partial class Program { }
+static void AddScopeEntries(Dictionary<string, string?> map, string envVar, string configPrefix)
+{
+    var raw = Environment.GetEnvironmentVariable(envVar);
+    if (raw is null) return;
+
+    var index = 0;
+    foreach (var entry in raw.Split(',').Select(e => e.Trim()).Where(e => e.Length > 0))
+    {
+        if (!ScopeEntryRegex.IsMatch(entry))
+            continue;
+        map[$"{configPrefix}:{index++}"] = entry;
+    }
+}
+
+public partial class Program
+{
+    private static readonly Regex ScopeEntryRegex = new(@"^[a-zA-Z0-9_-]+$", RegexOptions.Compiled);
+}

--- a/src/BookStack.Mcp.Server/Program.cs
+++ b/src/BookStack.Mcp.Server/Program.cs
@@ -114,7 +114,9 @@ static bool IsAuthorized(string authorizationHeader, ReadOnlyMemory<byte> expect
 {
     const string bearerPrefix = "Bearer ";
     if (!authorizationHeader.StartsWith(bearerPrefix, StringComparison.Ordinal))
+    {
         return false;
+    }
 
     var provided = Encoding.UTF8.GetBytes(authorizationHeader[bearerPrefix.Length..]);
     return provided.Length == expected.Length
@@ -142,7 +144,7 @@ static Dictionary<string, string?> MapBookStackEnvVars()
         }
     }
 
-    AddScopeEntries(map, "BOOKSTACK_SCOPED_BOOKS",   "BookStack:ScopedBooks");
+    AddScopeEntries(map, "BOOKSTACK_SCOPED_BOOKS", "BookStack:ScopedBooks");
     AddScopeEntries(map, "BOOKSTACK_SCOPED_SHELVES", "BookStack:ScopedShelves");
 
     return map;
@@ -151,18 +153,24 @@ static Dictionary<string, string?> MapBookStackEnvVars()
 static void AddScopeEntries(Dictionary<string, string?> map, string envVar, string configPrefix)
 {
     var raw = Environment.GetEnvironmentVariable(envVar);
-    if (raw is null) return;
+    if (raw is null)
+    {
+        return;
+    }
 
     var index = 0;
     foreach (var entry in raw.Split(',').Select(e => e.Trim()).Where(e => e.Length > 0))
     {
-        if (!ScopeEntryRegex.IsMatch(entry))
+        if (!_scopeEntryRegex.IsMatch(entry))
+        {
             continue;
+        }
+
         map[$"{configPrefix}:{index++}"] = entry;
     }
 }
 
 public partial class Program
 {
-    private static readonly Regex ScopeEntryRegex = new(@"^[a-zA-Z0-9_-]+$", RegexOptions.Compiled);
+    private static readonly Regex _scopeEntryRegex = new(@"^[a-zA-Z0-9_-]+$", RegexOptions.Compiled);
 }

--- a/src/BookStack.Mcp.Server/api/BookStackServiceCollectionExtensions.cs
+++ b/src/BookStack.Mcp.Server/api/BookStackServiceCollectionExtensions.cs
@@ -14,6 +14,9 @@ public static class BookStackServiceCollectionExtensions
         services.Configure<BookStackApiClientOptions>(
             configuration.GetSection("BookStack"));
 
+        services.Configure<ScopeFilterOptions>(
+            configuration.GetSection("BookStack"));
+
         services.AddSingleton<IValidateOptions<BookStackApiClientOptions>,
             BookStackApiClientOptionsValidator>();
 

--- a/src/BookStack.Mcp.Server/config/ScopeFilter.cs
+++ b/src/BookStack.Mcp.Server/config/ScopeFilter.cs
@@ -1,0 +1,16 @@
+namespace BookStack.Mcp.Server.Config;
+
+internal static class ScopeFilter
+{
+    internal static bool MatchesScope(int id, string slug, IReadOnlyList<string> scope)
+    {
+        foreach (var entry in scope)
+        {
+            if (int.TryParse(entry, out var scopeId) && scopeId == id)
+                return true;
+            if (string.Equals(entry, slug, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/BookStack.Mcp.Server/config/ScopeFilter.cs
+++ b/src/BookStack.Mcp.Server/config/ScopeFilter.cs
@@ -7,9 +7,14 @@ internal static class ScopeFilter
         foreach (var entry in scope)
         {
             if (int.TryParse(entry, out var scopeId) && scopeId == id)
+            {
                 return true;
+            }
+
             if (string.Equals(entry, slug, StringComparison.OrdinalIgnoreCase))
+            {
                 return true;
+            }
         }
         return false;
     }

--- a/src/BookStack.Mcp.Server/config/ScopeFilterOptions.cs
+++ b/src/BookStack.Mcp.Server/config/ScopeFilterOptions.cs
@@ -1,0 +1,10 @@
+namespace BookStack.Mcp.Server.Config;
+
+public sealed class ScopeFilterOptions
+{
+    public IReadOnlyList<string> ScopedShelves { get; set; } = [];
+    public IReadOnlyList<string> ScopedBooks { get; set; } = [];
+
+    public bool HasBookScope => ScopedBooks.Count > 0;
+    public bool HasShelfScope => ScopedShelves.Count > 0;
+}

--- a/src/BookStack.Mcp.Server/resources/books/BookResourceHandler.cs
+++ b/src/BookStack.Mcp.Server/resources/books/BookResourceHandler.cs
@@ -1,17 +1,23 @@
 using System.ComponentModel;
 using System.Text.Json;
 using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Config;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ModelContextProtocol.Server;
 
 namespace BookStack.Mcp.Server.Resources.Books;
 
 [McpServerResourceType]
 internal sealed class BookResourceHandler(
-    IBookStackApiClient client, ILogger<BookResourceHandler> logger)
+    IBookStackApiClient client,
+    ILogger<BookResourceHandler> logger,
+    IOptions<ScopeFilterOptions> scopeOptions)
 {
     private readonly IBookStackApiClient _client = client;
     private readonly ILogger<BookResourceHandler> _logger = logger;
+    private readonly IOptions<ScopeFilterOptions> _scopeOptions = scopeOptions;
 
     private static readonly JsonSerializerOptions _jsonOptions = new()
     {
@@ -26,6 +32,14 @@ internal sealed class BookResourceHandler(
         try
         {
             var result = await _client.ListBooksAsync(null, ct).ConfigureAwait(false);
+            var scope = _scopeOptions.Value;
+            if (scope.HasBookScope)
+            {
+                var filtered = result.Data
+                    .Where(b => ScopeFilter.MatchesScope(b.Id, b.Slug, scope.ScopedBooks))
+                    .ToList();
+                result = new ListResponse<Book> { Total = filtered.Count, From = result.From, To = result.To, Data = filtered };
+            }
             return JsonSerializer.Serialize(result, _jsonOptions);
         }
         catch (BookStackApiException ex)

--- a/src/BookStack.Mcp.Server/resources/shelves/ShelfResourceHandler.cs
+++ b/src/BookStack.Mcp.Server/resources/shelves/ShelfResourceHandler.cs
@@ -1,17 +1,23 @@
 using System.ComponentModel;
 using System.Text.Json;
 using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Config;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ModelContextProtocol.Server;
 
 namespace BookStack.Mcp.Server.Resources.Shelves;
 
 [McpServerResourceType]
 internal sealed class ShelfResourceHandler(
-    IBookStackApiClient client, ILogger<ShelfResourceHandler> logger)
+    IBookStackApiClient client,
+    ILogger<ShelfResourceHandler> logger,
+    IOptions<ScopeFilterOptions> scopeOptions)
 {
     private readonly IBookStackApiClient _client = client;
     private readonly ILogger<ShelfResourceHandler> _logger = logger;
+    private readonly IOptions<ScopeFilterOptions> _scopeOptions = scopeOptions;
 
     private static readonly JsonSerializerOptions _jsonOptions = new()
     {
@@ -26,6 +32,14 @@ internal sealed class ShelfResourceHandler(
         try
         {
             var result = await _client.ListShelvesAsync(null, ct).ConfigureAwait(false);
+            var scope = _scopeOptions.Value;
+            if (scope.HasShelfScope)
+            {
+                var filtered = result.Data
+                    .Where(s => ScopeFilter.MatchesScope(s.Id, s.Slug, scope.ScopedShelves))
+                    .ToList();
+                result = new ListResponse<Bookshelf> { Total = filtered.Count, From = result.From, To = result.To, Data = filtered };
+            }
             return JsonSerializer.Serialize(result, _jsonOptions);
         }
         catch (BookStackApiException ex)

--- a/src/BookStack.Mcp.Server/tools/books/BookToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/books/BookToolHandler.cs
@@ -3,16 +3,22 @@ using System.ComponentModel;
 using System.Text.Json;
 using BookStack.Mcp.Server.Api;
 using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Config;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ModelContextProtocol.Server;
 
 namespace BookStack.Mcp.Server.Tools.Books;
 
 [McpServerToolType]
-internal sealed class BookToolHandler(IBookStackApiClient client, ILogger<BookToolHandler> logger)
+internal sealed class BookToolHandler(
+    IBookStackApiClient client,
+    ILogger<BookToolHandler> logger,
+    IOptions<ScopeFilterOptions> scopeOptions)
 {
     private readonly IBookStackApiClient _client = client;
     private readonly ILogger<BookToolHandler> _logger = logger;
+    private readonly IOptions<ScopeFilterOptions> _scopeOptions = scopeOptions;
 
     private static readonly JsonSerializerOptions _jsonOptions = new()
     {
@@ -34,6 +40,14 @@ internal sealed class BookToolHandler(IBookStackApiClient client, ILogger<BookTo
                 ? new ListQueryParams { Count = count, Offset = offset, Sort = sort }
                 : null;
             var result = await _client.ListBooksAsync(query, ct).ConfigureAwait(false);
+            var scope = _scopeOptions.Value;
+            if (scope.HasBookScope)
+            {
+                var filtered = result.Data
+                    .Where(b => ScopeFilter.MatchesScope(b.Id, b.Slug, scope.ScopedBooks))
+                    .ToList();
+                result = new ListResponse<Book> { Total = filtered.Count, From = result.From, To = result.To, Data = filtered };
+            }
             return JsonSerializer.Serialize(result, _jsonOptions);
         }
         catch (BookStackApiException ex) when (ex.StatusCode == 404)

--- a/src/BookStack.Mcp.Server/tools/search/SearchToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/search/SearchToolHandler.cs
@@ -2,16 +2,22 @@ using System.ComponentModel;
 using System.Text.Json;
 using BookStack.Mcp.Server.Api;
 using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Config;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ModelContextProtocol.Server;
 
 namespace BookStack.Mcp.Server.Tools.Search;
 
 [McpServerToolType]
-internal sealed class SearchToolHandler(IBookStackApiClient client, ILogger<SearchToolHandler> logger)
+internal sealed class SearchToolHandler(
+    IBookStackApiClient client,
+    ILogger<SearchToolHandler> logger,
+    IOptions<ScopeFilterOptions> scopeOptions)
 {
     private readonly IBookStackApiClient _client = client;
     private readonly ILogger<SearchToolHandler> _logger = logger;
+    private readonly IOptions<ScopeFilterOptions> _scopeOptions = scopeOptions;
 
     private static readonly JsonSerializerOptions _jsonOptions = new()
     {
@@ -43,6 +49,17 @@ internal sealed class SearchToolHandler(IBookStackApiClient client, ILogger<Sear
                 Count = count,
             };
             var result = await _client.SearchAsync(request, ct).ConfigureAwait(false);
+            var scope = _scopeOptions.Value;
+            if (scope.HasBookScope)
+            {
+                var filtered = result.Data
+                    .Where(item =>
+                        item.Type == "book"
+                            ? ScopeFilter.MatchesScope(item.Id, item.Slug, scope.ScopedBooks)
+                            : item.Book is not null && ScopeFilter.MatchesScope(item.Book.Id, item.Book.Slug, scope.ScopedBooks))
+                    .ToList();
+                result = new SearchResult { Total = filtered.Count, From = result.From, To = result.To, Data = filtered };
+            }
             return JsonSerializer.Serialize(result, _jsonOptions);
         }
         catch (BookStackApiException ex)

--- a/src/BookStack.Mcp.Server/tools/shelves/ShelfToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/shelves/ShelfToolHandler.cs
@@ -3,16 +3,22 @@ using System.ComponentModel;
 using System.Text.Json;
 using BookStack.Mcp.Server.Api;
 using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Config;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ModelContextProtocol.Server;
 
 namespace BookStack.Mcp.Server.Tools.Shelves;
 
 [McpServerToolType]
-internal sealed class ShelfToolHandler(IBookStackApiClient client, ILogger<ShelfToolHandler> logger)
+internal sealed class ShelfToolHandler(
+    IBookStackApiClient client,
+    ILogger<ShelfToolHandler> logger,
+    IOptions<ScopeFilterOptions> scopeOptions)
 {
     private readonly IBookStackApiClient _client = client;
     private readonly ILogger<ShelfToolHandler> _logger = logger;
+    private readonly IOptions<ScopeFilterOptions> _scopeOptions = scopeOptions;
 
     private static readonly JsonSerializerOptions _jsonOptions = new()
     {
@@ -34,6 +40,14 @@ internal sealed class ShelfToolHandler(IBookStackApiClient client, ILogger<Shelf
                 ? new ListQueryParams { Count = count, Offset = offset, Sort = sort }
                 : null;
             var result = await _client.ListShelvesAsync(query, ct).ConfigureAwait(false);
+            var scope = _scopeOptions.Value;
+            if (scope.HasShelfScope)
+            {
+                var filtered = result.Data
+                    .Where(s => ScopeFilter.MatchesScope(s.Id, s.Slug, scope.ScopedShelves))
+                    .ToList();
+                result = new ListResponse<Bookshelf> { Total = filtered.Count, From = result.From, To = result.To, Data = filtered };
+            }
             return JsonSerializer.Serialize(result, _jsonOptions);
         }
         catch (BookStackApiException ex) when (ex.StatusCode == 422)

--- a/tests/BookStack.Mcp.Server.Tests/Http/BearerAuthMiddlewareTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/Http/BearerAuthMiddlewareTests.cs
@@ -1,7 +1,7 @@
-using FluentAssertions;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
+using FluentAssertions;
 
 namespace BookStack.Mcp.Server.Tests.Http;
 

--- a/tests/BookStack.Mcp.Server.Tests/Http/HealthEndpointTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/Http/HealthEndpointTests.cs
@@ -1,6 +1,6 @@
-using FluentAssertions;
 using System.Net;
 using System.Text.Json;
+using FluentAssertions;
 
 namespace BookStack.Mcp.Server.Tests.Http;
 

--- a/tests/BookStack.Mcp.Server.Tests/config/ScopeFilterTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/config/ScopeFilterTests.cs
@@ -1,0 +1,52 @@
+using BookStack.Mcp.Server.Config;
+using FluentAssertions;
+
+namespace BookStack.Mcp.Server.Tests.Config;
+
+public sealed class ScopeFilterTests
+{
+    [Test]
+    public void MatchesScope_EmptyScope_ReturnsFalse()
+    {
+        ScopeFilter.MatchesScope(1, "my-book", []).Should().BeFalse();
+    }
+
+    [Test]
+    public void MatchesScope_MatchesById()
+    {
+        ScopeFilter.MatchesScope(42, "any-slug", ["42"]).Should().BeTrue();
+    }
+
+    [Test]
+    public void MatchesScope_MatchesBySlug_CaseInsensitive()
+    {
+        ScopeFilter.MatchesScope(1, "My-Book", ["my-book"]).Should().BeTrue();
+    }
+
+    [Test]
+    public void MatchesScope_SlugComparison_IgnoresCase()
+    {
+        ScopeFilter.MatchesScope(1, "MY-BOOK", ["my-book"]).Should().BeTrue();
+    }
+
+    [Test]
+    public void MatchesScope_NoMatch_ReturnsFalse()
+    {
+        ScopeFilter.MatchesScope(1, "book-a", ["2", "book-b"]).Should().BeFalse();
+    }
+
+    [Test]
+    public void MatchesScope_MultipleEntries_MatchesCorrectId()
+    {
+        ScopeFilter.MatchesScope(5, "slug-5", ["1", "2", "5"]).Should().BeTrue();
+    }
+
+    [Test]
+    public void MatchesScope_IntegerIdDoesNotMatchSlugNumerically()
+    {
+        // "42" in scope should only match id==42, not slug=="42-something"
+        ScopeFilter.MatchesScope(1, "42", ["42"]).Should().BeTrue(); // slug match
+        ScopeFilter.MatchesScope(42, "other", ["42"]).Should().BeTrue(); // id match
+        ScopeFilter.MatchesScope(1, "nope", ["42"]).Should().BeFalse(); // neither
+    }
+}

--- a/tests/BookStack.Mcp.Server.Tests/resources/books/BookResourceHandlerTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/resources/books/BookResourceHandlerTests.cs
@@ -1,9 +1,11 @@
 using System.Text.Json;
 using BookStack.Mcp.Server.Api;
 using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Config;
 using BookStack.Mcp.Server.Resources.Books;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace BookStack.Mcp.Server.Tests.Resources.Books;
@@ -15,7 +17,10 @@ public sealed class BookResourceHandlerTests
 
     public BookResourceHandlerTests()
     {
-        _handler = new BookResourceHandler(_client.Object, NullLogger<BookResourceHandler>.Instance);
+        _handler = new BookResourceHandler(
+            _client.Object,
+            NullLogger<BookResourceHandler>.Instance,
+            Options.Create(new ScopeFilterOptions()));
     }
 
     [Test]
@@ -41,5 +46,32 @@ public sealed class BookResourceHandlerTests
 
         var doc = JsonDocument.Parse(result);
         doc.RootElement.GetProperty("id").GetInt32().Should().Be(7);
+    }
+
+    [Test]
+    public async Task GetBooksResource_WithBookScope_FiltersResults()
+    {
+        var scopedHandler = new BookResourceHandler(
+            _client.Object,
+            NullLogger<BookResourceHandler>.Instance,
+            Options.Create(new ScopeFilterOptions { ScopedBooks = ["scoped-book"] }));
+
+        _client.Setup(c => c.ListBooksAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListResponse<Book>
+            {
+                Total = 2,
+                Data =
+                [
+                    new Book { Id = 1, Slug = "scoped-book" },
+                    new Book { Id = 2, Slug = "excluded-book" },
+                ],
+            });
+
+        var result = await scopedHandler.GetBooksAsync().ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("total").GetInt32().Should().Be(1);
+        doc.RootElement.GetProperty("data").GetArrayLength().Should().Be(1);
+        doc.RootElement.GetProperty("data")[0].GetProperty("slug").GetString().Should().Be("scoped-book");
     }
 }

--- a/tests/BookStack.Mcp.Server.Tests/tools/books/BookToolHandlerTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/tools/books/BookToolHandlerTests.cs
@@ -1,9 +1,11 @@
 using System.Text.Json;
 using BookStack.Mcp.Server.Api;
 using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Config;
 using BookStack.Mcp.Server.Tools.Books;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace BookStack.Mcp.Server.Tests.Tools.Books;
@@ -15,7 +17,10 @@ public sealed class BookToolHandlerTests
 
     public BookToolHandlerTests()
     {
-        _handler = new BookToolHandler(_client.Object, NullLogger<BookToolHandler>.Instance);
+        _handler = new BookToolHandler(
+            _client.Object,
+            NullLogger<BookToolHandler>.Instance,
+            Options.Create(new ScopeFilterOptions()));
     }
 
     [Test]
@@ -144,5 +149,43 @@ public sealed class BookToolHandlerTests
         var result = await _handler.ExportBookAsync(1, "markdown").ConfigureAwait(false);
 
         result.Should().Be("# My Book");
+    }
+
+    [Test]
+    public async Task ListBooksAsync_WithBookScope_FiltersResults()
+    {
+        var scopedHandler = new BookToolHandler(
+            _client.Object,
+            NullLogger<BookToolHandler>.Instance,
+            Options.Create(new ScopeFilterOptions { ScopedBooks = ["my-book"] }));
+
+        _client.Setup(c => c.ListBooksAsync(It.IsAny<ListQueryParams?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListResponse<Book>
+            {
+                Total = 2,
+                Data = [
+                    new Book { Id = 1, Slug = "my-book" },
+                    new Book { Id = 2, Slug = "other-book" },
+                ],
+            });
+
+        var json = await scopedHandler.ListBooksAsync().ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("total").GetInt32().Should().Be(1);
+        doc.RootElement.GetProperty("data").GetArrayLength().Should().Be(1);
+        doc.RootElement.GetProperty("data")[0].GetProperty("slug").GetString().Should().Be("my-book");
+    }
+
+    [Test]
+    public async Task ListBooksAsync_WithEmptyScope_ReturnsAllBooks()
+    {
+        _client.Setup(c => c.ListBooksAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListResponse<Book> { Total = 2, Data = [new Book { Id = 1 }, new Book { Id = 2 }] });
+
+        var json = await _handler.ListBooksAsync().ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("total").GetInt32().Should().Be(2);
     }
 }

--- a/tests/BookStack.Mcp.Server.Tests/tools/search/SearchToolHandlerTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/tools/search/SearchToolHandlerTests.cs
@@ -1,9 +1,11 @@
 using System.Text.Json;
 using BookStack.Mcp.Server.Api;
 using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Config;
 using BookStack.Mcp.Server.Tools.Search;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace BookStack.Mcp.Server.Tests.Tools.Search;
@@ -15,7 +17,10 @@ public sealed class SearchToolHandlerTests
 
     public SearchToolHandlerTests()
     {
-        _handler = new SearchToolHandler(_client.Object, NullLogger<SearchToolHandler>.Instance);
+        _handler = new SearchToolHandler(
+            _client.Object,
+            NullLogger<SearchToolHandler>.Instance,
+            Options.Create(new ScopeFilterOptions()));
     }
 
     [Test]
@@ -82,5 +87,53 @@ public sealed class SearchToolHandlerTests
 
         var doc = JsonDocument.Parse(result);
         doc.RootElement.GetProperty("error").GetString().Should().Be("api_error");
+    }
+
+    [Test]
+    public async Task SearchAsync_WithBookScope_FiltersBookItems()
+    {
+        var scopedHandler = new SearchToolHandler(
+            _client.Object,
+            NullLogger<SearchToolHandler>.Instance,
+            Options.Create(new ScopeFilterOptions { ScopedBooks = ["allowed-book"] }));
+
+        _client.Setup(c => c.SearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SearchResult
+            {
+                Total = 3,
+                Data = [
+                    new SearchResultItem { Id = 1, Slug = "allowed-book",  Type = "book" },
+                    new SearchResultItem { Id = 2, Slug = "other-book",    Type = "book" },
+                    new SearchResultItem { Id = 3, Slug = "page-in-allowed", Type = "page",
+                        Book = new Book { Id = 1, Slug = "allowed-book" } },
+                ],
+            });
+
+        var json = await scopedHandler.SearchAsync("test").ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("total").GetInt32().Should().Be(2);
+        doc.RootElement.GetProperty("data").GetArrayLength().Should().Be(2);
+    }
+
+    [Test]
+    public async Task SearchAsync_WithBookScope_ExcludesPageWithNoBook()
+    {
+        var scopedHandler = new SearchToolHandler(
+            _client.Object,
+            NullLogger<SearchToolHandler>.Instance,
+            Options.Create(new ScopeFilterOptions { ScopedBooks = ["allowed-book"] }));
+
+        _client.Setup(c => c.SearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SearchResult
+            {
+                Total = 1,
+                Data = [new SearchResultItem { Id = 5, Slug = "orphan-page", Type = "page", Book = null }],
+            });
+
+        var json = await scopedHandler.SearchAsync("test").ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("total").GetInt32().Should().Be(0);
     }
 }

--- a/tests/BookStack.Mcp.Server.Tests/tools/shelves/ShelfToolHandlerTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/tools/shelves/ShelfToolHandlerTests.cs
@@ -1,9 +1,11 @@
 using System.Text.Json;
 using BookStack.Mcp.Server.Api;
 using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Config;
 using BookStack.Mcp.Server.Tools.Shelves;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace BookStack.Mcp.Server.Tests.Tools.Shelves;
@@ -15,7 +17,10 @@ public sealed class ShelfToolHandlerTests
 
     public ShelfToolHandlerTests()
     {
-        _handler = new ShelfToolHandler(_client.Object, NullLogger<ShelfToolHandler>.Instance);
+        _handler = new ShelfToolHandler(
+            _client.Object,
+            NullLogger<ShelfToolHandler>.Instance,
+            Options.Create(new ScopeFilterOptions()));
     }
 
     [Test]
@@ -60,5 +65,30 @@ public sealed class ShelfToolHandlerTests
         var doc = JsonDocument.Parse(result);
         doc.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
         doc.RootElement.GetProperty("message").GetString().Should().Contain("4");
+    }
+
+    [Test]
+    public async Task ListShelvesAsync_WithShelfScope_FiltersResults()
+    {
+        var scopedHandler = new ShelfToolHandler(
+            _client.Object,
+            NullLogger<ShelfToolHandler>.Instance,
+            Options.Create(new ScopeFilterOptions { ScopedShelves = ["my-shelf"] }));
+
+        _client.Setup(c => c.ListShelvesAsync(It.IsAny<ListQueryParams?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListResponse<Bookshelf>
+            {
+                Total = 2,
+                Data = [
+                    new Bookshelf { Id = 1, Slug = "my-shelf" },
+                    new Bookshelf { Id = 2, Slug = "other-shelf" },
+                ],
+            });
+
+        var json = await scopedHandler.ListShelvesAsync().ConfigureAwait(false);
+
+        var doc2 = JsonDocument.Parse(json);
+        doc2.RootElement.GetProperty("total").GetInt32().Should().Be(1);
+        doc2.RootElement.GetProperty("data")[0].GetProperty("slug").GetString().Should().Be("my-shelf");
     }
 }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -52,6 +52,18 @@
           "default": "",
           "secret": true,
           "markdownDescription": "BookStack API token secret corresponding to `bookstack.tokenId`."
+        },
+        "bookstack.scopedBooks": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "markdownDescription": "Restrict the MCP server to specific books. Each entry is a book ID (e.g. `42`) or slug (e.g. `my-book`). Leave empty for no restriction."
+        },
+        "bookstack.scopedShelves": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "markdownDescription": "Restrict the MCP server to specific shelves. Each entry is a shelf ID (e.g. `5`) or slug (e.g. `my-shelf`). Leave empty for no restriction."
         }
       }
     }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -44,6 +44,8 @@ export function activate(context: vscode.ExtensionContext): void {
                 const url = config.get<string>('url', '').trim();
                 const tokenId = config.get<string>('tokenId', '').trim();
                 const tokenSecret = config.get<string>('tokenSecret', '').trim();
+                const scopedBooks = config.get<string[]>('scopedBooks', []);
+                const scopedShelves = config.get<string[]>('scopedShelves', []);
 
                 if (!url || !tokenId || !tokenSecret) {
                     vscode.window.showWarningMessage(
@@ -68,6 +70,8 @@ export function activate(context: vscode.ExtensionContext): void {
                         {
                             BOOKSTACK_BASE_URL: url,
                             BOOKSTACK_TOKEN_SECRET: `${tokenId}:${tokenSecret}`,
+                            ...(scopedBooks.length > 0 && { BOOKSTACK_SCOPED_BOOKS: scopedBooks.join(',') }),
+                            ...(scopedShelves.length > 0 && { BOOKSTACK_SCOPED_SHELVES: scopedShelves.join(',') }),
                         }
                     )
                 ];


### PR DESCRIPTION
## Summary

Implements Feature #54 — Book/Shelf Scope Filtering. Allows the MCP server to be restricted to a specific subset of books and/or shelves, so AI assistants only see the content they should.

### How it works

Set `BOOKSTACK_SCOPED_BOOKS` and/or `BOOKSTACK_SCOPED_SHELVES` as comma-separated IDs or slugs. Results are post-fetch filtered at the MCP tool/resource layer (BookStack API has no multi-ID filter surface). Empty values mean no restriction — fully backward compatible.

### Changes

**Config & DI (#73)**
- `ScopeFilterOptions` — `ScopedBooks` / `ScopedShelves` as `IReadOnlyList<string>` with `HasBookScope` / `HasShelfScope` helpers
- `ScopeFilter` — static `MatchesScope(id, slug, scope)` — matches by integer ID or case-insensitive slug
- `Program.cs` — parses `BOOKSTACK_SCOPED_BOOKS` / `BOOKSTACK_SCOPED_SHELVES` env vars (comma-split, regex-validated `^[a-zA-Z0-9_-]+$`, indexed config keys)
- `BookStackServiceCollectionExtensions` — registers `IOptions<ScopeFilterOptions>` via `GetSection("BookStack")`

**Tool handler filtering (#74)**
- `BookToolHandler` — filters `ListBooksAsync` results by `ScopedBooks`
- `ShelfToolHandler` — filters `ListShelvesAsync` results by `ScopedShelves`
- `SearchToolHandler` — filters `SearchAsync` results: book-type items by their own ID/slug; other types by their parent `Book.Id/Slug`; items with no parent book are excluded when scope is active

**Resource handler filtering (#75)**
- `BookResourceHandler` — filters `GetBooksAsync` by `ScopedBooks`
- `ShelfResourceHandler` — filters `GetShelvesAsync` by `ScopedShelves`

**Tests (#77)** — 92 tests passing (up from 79)
- `ScopeFilterTests` — 6 unit tests for `MatchesScope`
- Scope filtering tests added to `BookToolHandlerTests`, `ShelfToolHandlerTests`, `SearchToolHandlerTests`, `BookResourceHandlerTests`

**VS Code extension (#76)**
- `bookstack.scopedBooks` and `bookstack.scopedShelves` array settings in `package.json`
- Mapped to `BOOKSTACK_SCOPED_BOOKS` / `BOOKSTACK_SCOPED_SHELVES` env vars at spawn; omitted when empty

### ADR

- ADR-0014: Scope Filter Architecture

Closes #54 #73 #74 #75 #76 #77