### PR TITLE
feat(#5,#11): Vector search engine and semantic search MCP tool (FEAT-0005)

### DIFF
--- a/docs/architecture/decisions/ADR-0015-vector-store-abstraction.md
+++ b/docs/architecture/decisions/ADR-0015-vector-store-abstraction.md
@@ -80,12 +80,12 @@ table schema; a minimal EF Core `SyncMetadataDbContext` handles the `sync_metada
 
 | Project | Package | Version |
 |---------|---------|---------|
-| `Data.Postgres` | `Npgsql` | `10.0.0` |
+| `Data.Postgres` | `Npgsql` | `10.0.2` |
 | `Data.Postgres` | `Npgsql.EntityFrameworkCore.PostgreSQL` | `10.0.0` |
 | `Data.Postgres` | `Pgvector` | `0.3.2` |
 | `Data.Postgres` | `Pgvector.EntityFrameworkCore` | `0.3.0` |
 | `Data.SqlServer` | `Microsoft.EntityFrameworkCore.SqlServer` | `10.*` (already referenced) |
-| `Data.Sqlite` | `Microsoft.SemanticKernel.Connectors.Sqlite` | `1.51.0-preview` |
+| `Data.Sqlite` | `Microsoft.SemanticKernel.Connectors.SqliteVec` | `1.74.0-preview` |
 | `Data.Sqlite` | `Microsoft.EntityFrameworkCore.Sqlite` | `10.*` (sync metadata table only) |
 
 ## Rationale
@@ -123,10 +123,11 @@ on earlier versions must use Postgres or SQLite.
 
 ### SQLite — Semantic Kernel SQLite connector
 
-`Microsoft.SemanticKernel.Connectors.Sqlite` provides native SQLite vector support via the SK
+`Microsoft.SemanticKernel.Connectors.SqliteVec` (the renamed successor to the deprecated
+`Microsoft.SemanticKernel.Connectors.Sqlite`) provides native SQLite vector support via the SK
 `IVectorStoreRecordCollection<K,V>` API. It handles schema creation, vector serialisation, and
 cosine similarity computation without requiring a separate native binary. The SK connector is
-currently preview (`1.51.0-preview`); if a breaking change occurs, the impact is confined to
+currently preview (`1.74.0-preview`); if a breaking change occurs, the impact is confined to
 `SqliteVectorStore` in `Data.Sqlite`. Sync metadata (content hash, last-sync timestamp) lives
 in a separate `sync_metadata` table managed by a minimal EF Core `SyncMetadataDbContext` with
 its own migration. The SQLite provider is intended for local/developer deployments; Postgres or

--- a/docs/architecture/decisions/ADR-0015-vector-store-abstraction.md
+++ b/docs/architecture/decisions/ADR-0015-vector-store-abstraction.md
@@ -1,0 +1,327 @@
+# ADR-0015: Vector Store Abstraction and Provider Selection
+
+**Status**: Accepted
+**Date**: 2026-04-26
+**Updated**: 2026-04-27
+**Author**: GitHub Copilot
+**Deciders**: Engineering team
+
+---
+
+## Context
+
+The Vector Search feature (FEAT-0005) requires persistent storage for page embedding vectors,
+per-page content hashes (for change detection), and the last-sync timestamp (for incremental
+indexing). Three deployment scenarios must be served:
+
+1. **Production — PostgreSQL** (`BookStack.Mcp.Server.Data.Postgres`): users already running
+   BookStack on PostgreSQL can enable pgvector with a single EF Core migration.
+2. **Team / enterprise — SQL Server** (`BookStack.Mcp.Server.Data.SqlServer`): SQL Server 2025
+   ships a native `VECTOR` datatype; organisations on SQL Server can use the same EF Core
+   migration pattern without a separate vector extension.
+3. **Lightweight / developer — SQLite** (`BookStack.Mcp.Server.Data.Sqlite`): local development
+   and single-user deployments that do not require a separate database service.
+4. **Unit tests**: no database process; tests must run in CI without any external service.
+
+ADR-0002 established the `Data.Abstractions` / per-provider project split specifically to
+support this pattern. This approach mirrors the data layer of
+[DeepWikiOpenDotnet](https://github.com/MarkZither/DeepWikiOpenDotnet/tree/main/src), where
+`Data.Abstractions` defines the interface and entity models, per-provider projects supply
+EF Core `DbContext`, entity configuration, and EF migrations, and the consuming service
+depends only on the abstraction.
+
+The abstraction must expose at minimum: upsert, cosine-similarity search (top-N, min-score
+threshold), delete-by-page-id, content-hash lookup, and last-sync-timestamp get/set. It must
+be mockable in unit tests without running a database.
+
+## Decision
+
+We will define a custom `IVectorStore` interface in `BookStack.Mcp.Server.Data.Abstractions`
+with four implementations selected at startup via the `VectorSearch:Database` configuration
+key (`"Postgres"` | `"SqlServer"` | `"Sqlite"` | `"InMemory"`).
+
+**Interface contract** (`IVectorStore`):
+
+```
+UpsertAsync(VectorPageEntry entry, ReadOnlyMemory<float> vector, ct)
+SearchAsync(ReadOnlyMemory<float> queryVector, int topN, float minScore, ct)
+  → IReadOnlyList<VectorSearchResult>
+DeleteAsync(int pageId, ct)
+GetContentHashAsync(int pageId, ct) → string?
+GetLastSyncAtAsync(ct) → DateTimeOffset?
+SetLastSyncAtAsync(DateTimeOffset timestamp, ct)
+```
+
+**Supporting types** (both in `Data.Abstractions`):
+
+- `VectorPageEntry` — carries `PageId`, `Slug`, `Title`, `Url`, `Excerpt`, `UpdatedAt`,
+  `ContentHash` for upsert and metadata storage.
+- `VectorSearchResult` — read model returned by `SearchAsync` with `PageId`, `Title`, `Url`,
+  `Excerpt`, `Score`.
+
+**Implementations**:
+
+| Key | Class | Project | Engine |
+|-----|-------|---------|--------|
+| `"Postgres"` | `PgVectorStore` | `Data.Postgres` | Npgsql.EntityFrameworkCore.PostgreSQL + Pgvector.EntityFrameworkCore; cosine similarity via `<=>` operator; HNSW index |
+| `"SqlServer"` | `SqlServerVectorStore` | `Data.SqlServer` | Microsoft.EntityFrameworkCore.SqlServer targeting SQL Server 2025 native `VECTOR` type; cosine similarity via `VECTOR_DISTANCE('cosine', ...)` |
+| `"Sqlite"` | `SqliteVectorStore` | `Data.Sqlite` | `Microsoft.SemanticKernel.Connectors.Sqlite` (SK SQLite connector); native SQLite vector support via the SK `IVectorStoreRecordCollection<K,V>` API; sync metadata in a separate `sync_metadata` table via EF Core Sqlite |
+| `"InMemory"` | `InMemoryVectorStore` | `Tests/Fakes` | `List<(VectorPageEntry, float[])>` with cosine similarity computed in C# |
+
+The active implementation is registered as `Singleton<IVectorStore>` in DI. For Postgres and
+SQL Server the corresponding `DbContext` is registered via the provider's `IServiceCollection`
+extension method; schema creation and updates are handled by **EF Core migrations** applied at
+startup via `dbContext.Database.MigrateAsync()`. For SQLite, the SK connector manages its own
+table schema; a minimal EF Core `SyncMetadataDbContext` handles the `sync_metadata` table
+(content hash, last-sync timestamp) and its migration. The `InMemory` implementation has no
+`DbContext` and requires no migration.
+
+**NuGet packages** to add/pin in provider projects:
+
+| Project | Package | Version |
+|---------|---------|---------|
+| `Data.Postgres` | `Npgsql` | `10.0.0` |
+| `Data.Postgres` | `Npgsql.EntityFrameworkCore.PostgreSQL` | `10.0.0` |
+| `Data.Postgres` | `Pgvector` | `0.3.2` |
+| `Data.Postgres` | `Pgvector.EntityFrameworkCore` | `0.3.0` |
+| `Data.SqlServer` | `Microsoft.EntityFrameworkCore.SqlServer` | `10.*` (already referenced) |
+| `Data.Sqlite` | `Microsoft.SemanticKernel.Connectors.Sqlite` | `1.51.0-preview` |
+| `Data.Sqlite` | `Microsoft.EntityFrameworkCore.Sqlite` | `10.*` (sync metadata table only) |
+
+## Rationale
+
+### EF Core + migrations, not a hand-rolled schema
+
+EF Core migrations provide a reproducible, version-controlled schema history. The same `dotnet
+ef migrations add` / `dotnet ef database update` workflow applies to all three database
+providers, and `MigrateAsync()` at startup means deployments are self-updating without any
+out-of-band DBA step. This matches the DeepWikiOpenDotnet approach that has already proven the
+pattern in production.
+
+### IVectorStore as custom interface, not Microsoft.Extensions.VectorData.Abstractions
+
+`Microsoft.Extensions.VectorData.Abstractions` (the Microsoft vector data abstraction) is in
+preview as of April 2026 and its API surface is still evolving for .NET 10. The pgvector and
+EF Core vector providers under that namespace have not reached stable status. A purpose-built
+`IVectorStore` with a minimal six-method surface gives full control and zero churn risk; it
+can be migrated to the Microsoft abstraction in a future ADR once it reaches GA.
+
+### PostgreSQL — pgvector via Npgsql
+
+Npgsql 10.0.0 and Pgvector.EntityFrameworkCore 0.3.0 are the current stable releases that
+target .NET 10 / EF Core 10. The `<=>` cosine distance operator is pushed server-side; an HNSW
+index (configured via entity configuration fluent API) provides sub-linear ANN query performance
+at indexing volumes typical for a BookStack instance (10k–100k pages).
+
+### SQL Server 2025 — native VECTOR type
+
+SQL Server 2025 introduces a first-class `VECTOR(n)` column type and the
+`VECTOR_DISTANCE('cosine', col, @query)` function. This eliminates any third-party extension;
+the Microsoft.EntityFrameworkCore.SqlServer provider maps the column natively once the
+`UseVectorSearch()` option is enabled. Targeting SQL Server 2025 is a deliberate choice — users
+on earlier versions must use Postgres or SQLite.
+
+### SQLite — Semantic Kernel SQLite connector
+
+`Microsoft.SemanticKernel.Connectors.Sqlite` provides native SQLite vector support via the SK
+`IVectorStoreRecordCollection<K,V>` API. It handles schema creation, vector serialisation, and
+cosine similarity computation without requiring a separate native binary. The SK connector is
+currently preview (`1.51.0-preview`); if a breaking change occurs, the impact is confined to
+`SqliteVectorStore` in `Data.Sqlite`. Sync metadata (content hash, last-sync timestamp) lives
+in a separate `sync_metadata` table managed by a minimal EF Core `SyncMetadataDbContext` with
+its own migration. The SQLite provider is intended for local/developer deployments; Postgres or
+SQL Server should be used for team or production workloads.
+
+### Singleton lifetime
+
+Vector store implementations are stateless DB clients backed by connection pools managed by EF
+Core. Registering as `Singleton` matches the `IDbContextFactory<T>` pattern used by the
+long-lived `VectorIndexSyncService`.
+
+## Alternatives Considered
+
+### Option A: Use Microsoft.Extensions.VectorData.Abstractions
+
+- **Pros**: Microsoft-supported; ecosystem alignment.
+- **Cons**: Preview API with breaking changes in .NET 10 RC cycle; EF Core vector providers
+  are not stable; tight coupling to a library the team does not control.
+- **Why rejected**: API instability risk; custom interface is simpler and already proven in
+  DeepWikiOpenDotnet.
+
+### Option B: Qdrant / Weaviate / Chroma via their .NET clients
+
+- **Pros**: Purpose-built vector databases; rich query capabilities.
+- **Cons**: Requires an additional external service; contradicts the project's goal of a
+  self-contained local tool.
+- **Why rejected**: Operational overhead not justified for a local MCP server scenario.
+
+### Option C: sqlite-vec native extension for SQLite
+
+- **Pros**: Potentially faster ANN queries via a purpose-built native vector index.
+- **Cons**: Requires distributing a native binary per platform; `NativeLibrary.Load` at startup
+  adds deployment complexity; the SK SQLite connector achieves the same result without any
+  native dependency.
+- **Why rejected**: Deployment complexity outweighs the benefit when `Microsoft.SemanticKernel
+  .Connectors.Sqlite` covers the same use case with a pure managed package.
+
+## Consequences
+
+### Positive
+
+- The main server (`BookStack.Mcp.Server`) depends only on `Data.Abstractions` — consistent with
+  ADR-0002; no DB driver leaks into the server assembly.
+- Providers swap via a single configuration key; no code change required.
+- EF Core migrations are version-controlled and self-applied at startup.
+- `InMemoryVectorStore` in the test project eliminates all database dependencies from unit tests.
+- SQL Server 2025 support means enterprise users on SQL Server have a first-class path without
+  requiring Postgres.
+
+### Negative / Trade-offs
+
+- SQLite vector search is O(n) — not suitable for large instances. Documentation must clearly
+  recommend Postgres or SQL Server for team use.
+- SQL Server 2025 is required for the SQL Server provider; older versions are not supported.
+- `IVectorStore` is a custom abstraction that must be maintained if requirements change.
+
+## Related ADRs
+
+- [ADR-0002: Solution and Project Structure](ADR-0002-solution-structure.md)
+- [ADR-0004: Test Framework](ADR-0004-test-framework.md)
+- [ADR-0016: Embedding Provider Abstraction](ADR-0016-embedding-provider-abstraction.md)
+
+
+The Vector Search feature (FEAT-0005) requires persistent storage for page embedding vectors,
+per-page content hashes (for change detection), and the last-sync timestamp (for incremental
+indexing). Three deployment scenarios must be served:
+
+1. **Production — PostgreSQL** (`BookStack.Mcp.Server.Data.Postgres`): users already running
+   BookStack on PostgreSQL can enable pgvector with a single migration.
+2. **Lightweight / developer — SQLite** (`BookStack.Mcp.Server.Data.Sqlite`): local development
+   and single-user deployments that do not require a separate database service.
+3. **Unit tests**: no database process; tests must run in CI without any external service.
+
+ADR-0002 established the `Data.Abstractions` / per-provider project split specifically to
+support this pattern. The SQL Server provider (`Data.SqlServer`) is explicitly out of scope
+for FEAT-0005 (no stable EF Core SQL Server vector extension at the time of writing).
+
+The abstraction must expose at minimum: upsert, cosine-similarity search (top-N, min-score
+threshold), delete-by-page-id, content-hash lookup, and last-sync-timestamp get/set. It must
+be mockable in unit tests without running a database.
+
+## Decision
+
+We will define a custom `IVectorStore` interface in `BookStack.Mcp.Server.Data.Abstractions`
+with three implementations selected at startup via the `VectorSearch:Database` configuration
+key (`"Postgres"` | `"Sqlite"` | `"InMemory"`).
+
+**Interface contract** (`IVectorStore`):
+
+```
+UpsertAsync(VectorPageEntry entry, ReadOnlyMemory<float> vector, ct)
+SearchAsync(ReadOnlyMemory<float> queryVector, int topN, float minScore, ct)
+  → IReadOnlyList<VectorSearchResult>
+DeleteAsync(int pageId, ct)
+GetContentHashAsync(int pageId, ct) → string?
+GetLastSyncAtAsync(ct) → DateTimeOffset?
+SetLastSyncAtAsync(DateTimeOffset timestamp, ct)
+```
+
+**Supporting types** (both in `Data.Abstractions`):
+
+- `VectorPageEntry` — carries `PageId`, `Slug`, `Title`, `Url`, `Excerpt`, `UpdatedAt`,
+  `ContentHash` for upsert and metadata storage.
+- `VectorSearchResult` — read model returned by `SearchAsync` with `PageId`, `Title`, `Url`,
+  `Excerpt`, `Score`.
+
+**Implementations**:
+
+| Key | Class | Project | Engine |
+|-----|-------|---------|--------|
+| `"Postgres"` | `PgVectorStore` | `Data.Postgres` | Npgsql + pgvector extension; cosine similarity via `<=>` operator |
+| `"Sqlite"` | `SqliteVecStore` | `Data.Sqlite` | `Microsoft.EntityFrameworkCore.Sqlite` + sqlite-vec native extension loaded at startup |
+| `"InMemory"` | `InMemoryVectorStore` | `Tests/Fakes` | `List<(VectorPageEntry, float[])>` with cosine similarity computed in C# |
+
+The active implementation is registered as `Singleton<IVectorStore>` in DI. For Postgres and
+SQLite, the corresponding `DbContext` is also registered by the provider's
+`IServiceCollection` extension method. The `InMemory` implementation has no `DbContext`.
+
+New NuGet references required:
+
+| Project | Package | Version |
+|---------|---------|---------|
+| `Data.Postgres` | `Pgvector` | `0.*` |
+| `Data.Sqlite` | `sqlite-vec` (native lib via `NativeLibrary.Load`) | n/a — loaded at runtime |
+
+## Rationale
+
+### IVectorStore as custom interface, not Microsoft.Extensions.VectorData.Abstractions
+
+`Microsoft.Extensions.VectorData.Abstractions` (the Microsoft vector data abstraction) is in
+preview as of April 2026 and its API surface is still evolving for .NET 10. The pgvector and
+sqlite-vec providers under that namespace have not reached stable status. Binding to it now
+risks breaking changes before the feature stabilises. A purpose-built `IVectorStore` with a
+minimal six-method surface gives full control and zero churn risk; it can be migrated to the
+Microsoft abstraction in a future ADR once it reaches GA.
+
+### Singleton lifetime
+
+Vector store implementations are stateless DB clients backed by connection pools managed by EF
+Core. Registering as `Singleton` matches EF Core `DbContext` factory pattern (`IDbContextFactory`)
+used by the long-lived `VectorIndexSyncService`.
+
+### Cosine similarity delegation
+
+pgvector and sqlite-vec both compute cosine similarity natively in the database, enabling
+server-side top-N filtering without loading all vectors into process memory.
+`InMemoryVectorStore` computes it in C# using the dot-product / magnitude formula; this is
+acceptable because the in-memory store is only used in unit tests with a small number of entries.
+
+## Alternatives Considered
+
+### Option A: Use Microsoft.Extensions.VectorData.Abstractions
+
+- **Pros**: Microsoft-supported; ecosystem alignment; potential future NuGet provider packages.
+- **Cons**: Preview API with breaking changes in .NET 10 RC cycle; pgvector and sqlite-vec
+  providers are not stable; tight coupling to a library the team does not control.
+- **Why rejected**: API instability risk is unacceptable for a feature targeting a stable release.
+
+### Option B: Qdrant / Weaviate / Chroma via their .NET clients
+
+- **Pros**: Purpose-built vector databases; rich query capabilities; cloud-native options.
+- **Cons**: Requires an additional external service; contradicts the project's goal of a
+  self-contained local tool; adds deployment complexity for users who only want local semantic
+  search.
+- **Why rejected**: Operational overhead is not justified for a local MCP server scenario.
+
+### Option C: Define IVectorStore inside the main server project
+
+- **Pros**: Slightly simpler — no cross-project reference needed for the in-memory test fake.
+- **Cons**: Violates ADR-0002's `Data.Abstractions` boundary; `Data.Postgres` and `Data.Sqlite`
+  cannot implement an interface they cannot reference; forces test fakes to import the main
+  server project.
+- **Why rejected**: Contradicts the architectural separation established in ADR-0002.
+
+## Consequences
+
+### Positive
+
+- The main server (`BookStack.Mcp.Server`) depends only on `Data.Abstractions` — consistent with
+  ADR-0002; no DB driver leaks into the server assembly.
+- Providers swap via a single configuration key; no code change required.
+- `InMemoryVectorStore` in the test project eliminates all database dependencies from unit tests.
+- The six-method interface is small enough to mock with Moq in a single `Setup` call per test.
+
+### Negative / Trade-offs
+
+- `IVectorStore` is a custom abstraction that must be maintained if requirements change (e.g.,
+  hybrid filtering, metadata-only queries).
+- The cosine similarity implementation in `InMemoryVectorStore` diverges from the SQL
+  implementations; tests must not rely on numerical precision parity between stores.
+- sqlite-vec is loaded via `NativeLibrary.Load` at startup; the native binary must be distributed
+  with the application for the SQLite provider to function.
+
+## Related ADRs
+
+- [ADR-0002: Solution and Project Structure](ADR-0002-solution-structure.md)
+- [ADR-0004: Test Framework](ADR-0004-test-framework.md)
+- [ADR-0016: Embedding Provider Abstraction](ADR-0016-embedding-provider-abstraction.md)

--- a/docs/architecture/decisions/ADR-0016-embedding-provider-abstraction.md
+++ b/docs/architecture/decisions/ADR-0016-embedding-provider-abstraction.md
@@ -1,0 +1,138 @@
+# ADR-0016: Embedding Provider Abstraction
+
+**Status**: Accepted
+**Date**: 2026-04-26
+**Author**: GitHub Copilot
+**Deciders**: Engineering team
+
+---
+
+## Context
+
+The Vector Search feature (FEAT-0005) requires converting page text to floating-point embedding
+vectors at both index time (sync service) and query time (tool handler). Two concrete providers
+must be supported:
+
+1. **Ollama** — local, privacy-preserving, no API key required; intended as the default for
+   self-hosted deployments. Model: `nomic-embed-text` (configurable).
+2. **Azure OpenAI** — cloud-hosted, higher-quality embeddings; intended for users with an Azure
+   subscription. Requires endpoint, deployment name, and API key from configuration.
+
+An abstraction is needed to allow the sync service and the tool handler to depend on a stable
+interface without coupling to either provider's SDK. The active provider is selected at startup
+via the `VectorSearch:EmbeddingProvider` configuration key (`"Ollama"` | `"AzureOpenAI"`).
+
+`Microsoft.Extensions.AI` is Microsoft's official .NET abstraction for AI model access. It
+defines `IEmbeddingGenerator<TInput, TEmbedding>` as a standard interface, ships built-in Ollama
+and Azure AI Inference extensions, and is the stated direction for the .NET AI ecosystem. The
+package reached RC status for .NET 10.
+
+## Decision
+
+We will use `IEmbeddingGenerator<string, Embedding<float>>` from `Microsoft.Extensions.AI` as
+the embedding abstraction with no custom wrapper interface.
+
+- When `VectorSearch:EmbeddingProvider` is `"Ollama"`: register
+  `OllamaEmbeddingGenerator` (from `Microsoft.Extensions.AI.Ollama`) pointing to
+  `VectorSearch:Ollama:BaseUrl` / `VectorSearch:Ollama:Model`.
+- When `VectorSearch:EmbeddingProvider` is `"AzureOpenAI"`: register an
+  `AzureOpenAIClient`-backed embedding generator (from `Azure.AI.OpenAI` +
+  `Microsoft.Extensions.AI` bridge) using `VectorSearch:AzureOpenAI:Endpoint`,
+  `VectorSearch:AzureOpenAI:DeploymentName`, and `VectorSearch:AzureOpenAI:ApiKey`.
+
+Both registrations are added as `Singleton<IEmbeddingGenerator<string, Embedding<float>>>` in
+the `AddVectorSearch` `IServiceCollection` extension method, guarded by the
+`VectorSearch:Enabled` flag.
+
+The Azure OpenAI API key is read exclusively from `IOptions<VectorSearchOptions>` and is never
+written to any log output, error string, or MCP tool response (enforced by structured logging
+patterns — see NF-4 in the spec).
+
+New NuGet references required in `BookStack.Mcp.Server.csproj`:
+
+| Package | Purpose |
+|---------|---------|
+| `Microsoft.Extensions.AI` | `IEmbeddingGenerator<TInput, TEmbedding>`, `Embedding<float>` |
+| `Microsoft.Extensions.AI.Ollama` | `OllamaEmbeddingGenerator` |
+| `Azure.AI.OpenAI` | `AzureOpenAIClient` (Azure OpenAI provider) |
+
+## Rationale
+
+### Use Microsoft.Extensions.AI, not a custom interface
+
+`Microsoft.Extensions.AI` is the official Microsoft abstraction for AI model access in .NET. It
+is backed by the .NET team, already has Ollama and Azure OpenAI first-party extensions, and is
+integrated with the `Microsoft.Extensions.DependencyInjection` ecosystem. Building a custom
+`IEmbeddingProvider` interface would reproduce the same six-method surface without ecosystem
+benefit, and any future third provider (e.g., a local OpenAI-compatible server) would require
+writing an adapter instead of pulling a NuGet package.
+
+The one risk — API changes in RC — is mitigated by the fact that `IEmbeddingGenerator` itself
+has been stable across the last three preview versions, and the method signature
+(`GenerateAsync(IEnumerable<TInput>, EmbeddingGenerationOptions?, ct)`) is unlikely to change
+before GA.
+
+### Ollama as default
+
+Ollama is self-hosted, requires no API key, and is already the model server used by many
+BookStack self-hosters for local LLMs. Setting it as the default minimises the barrier to
+enabling vector search without any cloud dependency.
+
+### API key security
+
+`VectorSearch:AzureOpenAI:ApiKey` is bound via `IOptions<VectorSearchOptions>`, which is
+populated from `IConfiguration` (environment variable `VECTORSEARCH__AZUREOPENAI__APIKEY` or
+`appsettings.json`). The options object is never serialised, logged, or included in tool
+responses; the structured logging constraint (NF-4) is a test requirement for the
+`SemanticSearchToolHandlerTests`.
+
+## Alternatives Considered
+
+### Option A: Custom IEmbeddingProvider wrapper interface
+
+- **Pros**: Full control; no dependency on a preview library.
+- **Cons**: Reinvents what `Microsoft.Extensions.AI` already provides; requires writing and
+  maintaining Ollama and Azure OpenAI adapter implementations; contradicts the .NET AI ecosystem
+  direction.
+- **Why rejected**: Unnecessary complexity when `IEmbeddingGenerator` meets all requirements
+  and is mockable with Moq without additional abstraction layers.
+
+### Option B: Semantic Kernel ITextEmbeddingGenerationService
+
+- **Pros**: Mature abstraction; large ecosystem of SK connectors.
+- **Cons**: Pulls in the full Semantic Kernel dependency tree; `ITextEmbeddingGenerationService`
+  is broader than required; Semantic Kernel is not a dependency of this project; the official
+  Microsoft guidance for new .NET projects is to use `Microsoft.Extensions.AI` directly.
+- **Why rejected**: Dependency weight and scope mismatch.
+
+### Option C: Azure OpenAI SDK only (no Ollama)
+
+- **Pros**: GA, well-documented, stable.
+- **Cons**: Requires an Azure subscription; violates requirement FR-10 (Ollama as local default);
+  no local provider path.
+- **Why rejected**: Does not satisfy FEAT-0005 requirements.
+
+## Consequences
+
+### Positive
+
+- `IEmbeddingGenerator<string, Embedding<float>>` is trivially mockable in TUnit tests with Moq
+  — no running embedding service required.
+- Switching providers (or adding a third, e.g., a locally hosted OpenAI-compatible server)
+  requires only a new DI branch, no interface changes.
+- `Microsoft.Extensions.AI` integrates directly with `IServiceCollection`, enabling the
+  standard `AddEmbeddingGenerator` / `UseLogging` / `UseOpenTelemetry` decorator chain for
+  future observability improvements.
+
+### Negative / Trade-offs
+
+- `Microsoft.Extensions.AI` is RC for .NET 10 at the time of this decision; if a breaking API
+  change is introduced before GA, the DI wiring code will need updating (limited surface area —
+  one `GenerateAsync` call in `VectorIndexSyncService` and one in `SemanticSearchToolHandler`).
+- The Ollama and Azure OpenAI NuGet packages are separate, increasing the total dependency count
+  by three packages in the main server project.
+
+## Related ADRs
+
+- [ADR-0001: MCP SDK Selection](ADR-0001-mcp-sdk-selection.md)
+- [ADR-0015: Vector Store Abstraction and Provider Selection](ADR-0015-vector-store-abstraction.md)

--- a/docs/features/vector-search/plan.md
+++ b/docs/features/vector-search/plan.md
@@ -1,0 +1,394 @@
+# Plan: Vector Search Engine and Semantic Search MCP Tool (FEAT-0005)
+
+**Feature**: Vector Search Engine and Semantic Search MCP Tool
+**Spec**: [docs/features/vector-search/spec.md](spec.md)
+**GitHub Issues**: [#5](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/5),
+[#11](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/11)
+**Parent Epic**: [#3](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/3)
+**Status**: Ready for Implementation
+**Date**: 2026-04-26
+
+---
+
+## Referenced ADRs
+
+| ADR | Title | Decision |
+|-----|-------|----------|
+| [ADR-0002](../../architecture/decisions/ADR-0002-solution-structure.md) | Solution Structure | `IVectorStore` in `Data.Abstractions`; implementations in `Data.Postgres`, `Data.Sqlite`, tests |
+| [ADR-0004](../../architecture/decisions/ADR-0004-test-framework.md) | Test Framework | TUnit + Moq; `InMemoryVectorStore` fake in `Tests/Fakes/` |
+| [ADR-0009](../../architecture/decisions/ADR-0009-dual-transport-entry-point.md) | Dual-Transport Entry Point | `AddVectorSearch` extension wired in `Program.cs`; `BackgroundService` registered only when `VectorSearch:Enabled = true` |
+| [ADR-0010](../../architecture/decisions/ADR-0010-tool-handler-output-json-policy.md) | Tool Handler Output JSON Policy | `bookstack_semantic_search` returns camelCase JSON via `JsonSerializerOptions.CamelCase` |
+| [ADR-0015](../../architecture/decisions/ADR-0015-vector-store-abstraction.md) | Vector Store Abstraction | `IVectorStore` custom interface; pgvector, sqlite-vec, in-memory implementations; provider via `VectorSearch:Database` |
+| [ADR-0016](../../architecture/decisions/ADR-0016-embedding-provider-abstraction.md) | Embedding Provider Abstraction | `IEmbeddingGenerator<string, Embedding<float>>` from `Microsoft.Extensions.AI`; Ollama default; Azure OpenAI alternative |
+
+---
+
+## New Types
+
+### Configuration Options
+
+```csharp
+// src/BookStack.Mcp.Server/config/VectorSearchOptions.cs
+namespace BookStack.Mcp.Server.Config;
+
+public sealed class VectorSearchOptions
+{
+    public bool Enabled { get; set; } = false;
+    public string EmbeddingProvider { get; set; } = "Ollama";
+    public string Database { get; set; } = "Sqlite";
+    public int SyncIntervalHours { get; set; } = 12;
+    public OllamaEmbeddingOptions Ollama { get; set; } = new();
+    public AzureOpenAIEmbeddingOptions AzureOpenAI { get; set; } = new();
+    public VectorSearchDefaults Search { get; set; } = new();
+}
+
+public sealed class OllamaEmbeddingOptions
+{
+    public string BaseUrl { get; set; } = "http://localhost:11434";
+    public string Model { get; set; } = "nomic-embed-text";
+}
+
+public sealed class AzureOpenAIEmbeddingOptions
+{
+    public string Endpoint { get; set; } = string.Empty;
+    public string DeploymentName { get; set; } = string.Empty;
+    public string ApiKey { get; set; } = string.Empty;
+}
+
+public sealed class VectorSearchDefaults
+{
+    public int DefaultTopN { get; set; } = 5;
+    public float DefaultMinScore { get; set; } = 0.7f;
+}
+```
+
+### IVectorStore Abstraction
+
+```csharp
+// src/BookStack.Mcp.Server.Data.Abstractions/IVectorStore.cs
+namespace BookStack.Mcp.Server.Data.Abstractions;
+
+public interface IVectorStore
+{
+    Task UpsertAsync(VectorPageEntry entry, ReadOnlyMemory<float> vector,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<VectorSearchResult>> SearchAsync(ReadOnlyMemory<float> queryVector,
+        int topN, float minScore, CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(int pageId, CancellationToken cancellationToken = default);
+
+    Task<string?> GetContentHashAsync(int pageId,
+        CancellationToken cancellationToken = default);
+
+    Task<DateTimeOffset?> GetLastSyncAtAsync(CancellationToken cancellationToken = default);
+
+    Task SetLastSyncAtAsync(DateTimeOffset timestamp,
+        CancellationToken cancellationToken = default);
+}
+```
+
+### Supporting Types (Data.Abstractions)
+
+```csharp
+// VectorPageEntry.cs
+public sealed class VectorPageEntry
+{
+    public int PageId { get; init; }
+    public string Slug { get; init; } = string.Empty;
+    public string Title { get; init; } = string.Empty;
+    public string Url { get; init; } = string.Empty;
+    public string Excerpt { get; init; } = string.Empty;       // first 300 chars of plain text
+    public DateTimeOffset UpdatedAt { get; init; }
+    public string ContentHash { get; init; } = string.Empty;  // SHA-256 of html_content
+}
+
+// VectorSearchResult.cs
+public sealed class VectorSearchResult
+{
+    public int PageId { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string Url { get; init; } = string.Empty;
+    public string Excerpt { get; init; } = string.Empty;
+    public float Score { get; init; }
+}
+```
+
+### IBookStackApiClient Extension
+
+Add to `IBookStackApiClient` and implement in `BookStackApiClient.Pages.cs`:
+
+```csharp
+// IBookStackApiClient.cs — new method in the Pages section
+Task<ListResponse<Page>> GetPagesUpdatedSinceAsync(DateTimeOffset since,
+    CancellationToken cancellationToken = default);
+```
+
+Implementation uses the BookStack API `filter[updated_at:gte]` query parameter:
+
+```csharp
+// BookStackApiClient.Pages.cs
+public Task<ListResponse<Page>> GetPagesUpdatedSinceAsync(
+    DateTimeOffset since,
+    CancellationToken cancellationToken = default)
+{
+    var ts = since.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ssZ");
+    var url = $"pages?filter[updated_at:gte]={Uri.EscapeDataString(ts)}&count=500";
+    return SendAsync<ListResponse<Page>>(JsonRequest(HttpMethod.Get, url), cancellationToken);
+}
+```
+
+> **Note**: The BookStack API returns up to 500 results per page. For deployments with more than
+> 500 pages changed in a single sync window, pagination via `offset` must be implemented in a
+> follow-up task. For v1, a single request with `count=500` is acceptable.
+
+---
+
+## File Locations
+
+| Artifact | Path |
+|----------|------|
+| Configuration options | `src/BookStack.Mcp.Server/config/VectorSearchOptions.cs` |
+| `IVectorStore` interface | `src/BookStack.Mcp.Server.Data.Abstractions/IVectorStore.cs` |
+| `VectorPageEntry` model | `src/BookStack.Mcp.Server.Data.Abstractions/VectorPageEntry.cs` |
+| `VectorSearchResult` model | `src/BookStack.Mcp.Server.Data.Abstractions/VectorSearchResult.cs` |
+| pgvector EF entity | `src/BookStack.Mcp.Server.Data.Postgres/VectorPageRecord.cs` |
+| `PgVectorStore` | `src/BookStack.Mcp.Server.Data.Postgres/PgVectorStore.cs` |
+| pgvector `DbContext` | `src/BookStack.Mcp.Server.Data.Postgres/VectorDbContext.cs` |
+| pgvector DI extension | `src/BookStack.Mcp.Server.Data.Postgres/PostgresVectorStoreServiceCollectionExtensions.cs` |
+| SQLite EF entity | `src/BookStack.Mcp.Server.Data.Sqlite/VectorPageRecord.cs` |
+| `SqliteVecStore` | `src/BookStack.Mcp.Server.Data.Sqlite/SqliteVecStore.cs` |
+| SQLite `DbContext` | `src/BookStack.Mcp.Server.Data.Sqlite/VectorDbContext.cs` |
+| SQLite DI extension | `src/BookStack.Mcp.Server.Data.Sqlite/SqliteVectorStoreServiceCollectionExtensions.cs` |
+| In-memory fake | `tests/BookStack.Mcp.Server.Tests/Fakes/InMemoryVectorStore.cs` |
+| Background sync service | `src/BookStack.Mcp.Server/services/VectorIndexSyncService.cs` |
+| Tool handler | `src/BookStack.Mcp.Server/tools/semantic-search/SemanticSearchToolHandler.cs` |
+| `IBookStackApiClient` extension | `src/BookStack.Mcp.Server/api/IBookStackApiClient.cs` (new method) |
+| API client implementation | `src/BookStack.Mcp.Server/api/BookStackApiClient.Pages.cs` (new method) |
+| DI wiring extension | `src/BookStack.Mcp.Server/api/VectorSearchServiceCollectionExtensions.cs` |
+
+---
+
+## NuGet Package Changes
+
+### BookStack.Mcp.Server.csproj
+
+Add:
+
+```xml
+<PackageReference Include="Microsoft.Extensions.AI" Version="9.*" />
+<PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.*" />
+<PackageReference Include="Azure.AI.OpenAI" Version="2.*" />
+```
+
+### BookStack.Mcp.Server.Data.Postgres.csproj
+
+Add:
+
+```xml
+<PackageReference Include="Pgvector" Version="0.*" />
+```
+
+*(Npgsql.EntityFrameworkCore.PostgreSQL already present — pgvector support is enabled via
+`UseVector()` in the `DbContextOptionsBuilder` and `Pgvector` provides the `Vector` CLR type.)*
+
+### BookStack.Mcp.Server.Data.Sqlite.csproj
+
+No additional NuGet packages. The sqlite-vec native library is loaded at runtime via
+`NativeLibrary.Load` from the application directory. The binary must be distributed alongside
+the application for the SQLite provider to function.
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Abstractions and Configuration
+
+| Task | File | Description |
+|------|------|-------------|
+| T1 | `config/VectorSearchOptions.cs` | Create `VectorSearchOptions`, `OllamaEmbeddingOptions`, `AzureOpenAIEmbeddingOptions`, `VectorSearchDefaults` |
+| T2 | `Data.Abstractions/IVectorStore.cs` | Define `IVectorStore` interface |
+| T3 | `Data.Abstractions/VectorPageEntry.cs` | Define `VectorPageEntry` record |
+| T4 | `Data.Abstractions/VectorSearchResult.cs` | Define `VectorSearchResult` record |
+
+### Phase 2 — API Client Extension
+
+| Task | File | Description |
+|------|------|-------------|
+| T5 | `api/IBookStackApiClient.cs` | Add `GetPagesUpdatedSinceAsync(DateTimeOffset since, ct)` |
+| T6 | `api/BookStackApiClient.Pages.cs` | Implement using `filter[updated_at:gte]` query parameter |
+
+### Phase 3 — Vector Store Implementations
+
+| Task | File | Description |
+|------|------|-------------|
+| T7 | `Data.Postgres/VectorPageRecord.cs` | EF Core entity with `Vector` property (Pgvector type), `page_id`, `slug`, `title`, `url`, `excerpt`, `updated_at`, `content_hash` |
+| T8 | `Data.Postgres/VectorDbContext.cs` | `DbContext` with `DbSet<VectorPageRecord>` and `SyncState` table; registers pgvector extension with `HasPostgresExtension("vector")` |
+| T9 | `Data.Postgres/PgVectorStore.cs` | Implement `IVectorStore`; `SearchAsync` uses `<=>` (cosine distance) via `EF.Functions.CosineDistance`; cosine **similarity** = `1 − distance` |
+| T10 | `Data.Postgres/PostgresVectorStoreServiceCollectionExtensions.cs` | `AddPgVectorStore(IServiceCollection, IConfiguration)` extension; registers `IDbContextFactory<VectorDbContext>` and `IVectorStore` |
+| T11 | `Data.Sqlite/VectorPageRecord.cs` | EF Core entity; vector stored as `BLOB` (raw `float[]` bytes) for sqlite-vec |
+| T12 | `Data.Sqlite/VectorDbContext.cs` | `DbContext`; calls `SqliteVec.Load()` on `Database.Connection` in `OnConfiguring` to activate the sqlite-vec extension |
+| T13 | `Data.Sqlite/SqliteVecStore.cs` | Implement `IVectorStore`; `SearchAsync` uses sqlite-vec virtual table query (`vec_distance_cosine`); results filtered to `minScore` in C# if the extension does not support threshold |
+| T14 | `Data.Sqlite/SqliteVectorStoreServiceCollectionExtensions.cs` | `AddSqliteVectorStore(IServiceCollection, IConfiguration)` extension |
+| T15 | `Tests/Fakes/InMemoryVectorStore.cs` | `IVectorStore` backed by `List<(VectorPageEntry entry, float[] vector)>`; `SearchAsync` computes cosine similarity in C#; thread-safe via `lock` |
+
+### Phase 4 — Background Sync Service
+
+| Task | File | Description |
+|------|------|-------------|
+| T16 | `services/VectorIndexSyncService.cs` | `BackgroundService` subclass; constructor-injects `IVectorStore`, `IEmbeddingGenerator<string, Embedding<float>>`, `IBookStackApiClient`, `IOptions<VectorSearchOptions>`, `ILogger<VectorIndexSyncService>` |
+| | | Loop: `await Task.Delay(interval, ct)` → `GetLastSyncAtAsync` → `GetPagesUpdatedSinceAsync` → per-page SHA-256 → `GetContentHashAsync` → skip or embed → `UpsertAsync` → `SetLastSyncAtAsync` |
+| | | Per-page errors caught, logged at `Warning`, loop continues |
+| | | `ExecuteAsync` exits cleanly when `CancellationToken` is cancelled (30-second shutdown budget) |
+
+**SHA-256 content hash helper** (inline static method in `VectorIndexSyncService`):
+
+```csharp
+private static string ComputeSha256(string content)
+{
+    var bytes = System.Text.Encoding.UTF8.GetBytes(content);
+    var hash = System.Security.Cryptography.SHA256.HashData(bytes);
+    return Convert.ToHexString(hash);
+}
+```
+
+**Excerpt extraction** (inline static method — first 300 characters of stripped plain text):
+
+```csharp
+private static string ExtractExcerpt(string htmlContent)
+{
+    // Strip HTML tags; take first 300 characters
+    var plain = System.Text.RegularExpressions.Regex.Replace(htmlContent, "<[^>]+>", " ");
+    plain = System.Text.RegularExpressions.Regex.Replace(plain, @"\s+", " ").Trim();
+    return plain.Length <= 300 ? plain : plain[..300];
+}
+```
+
+### Phase 5 — Semantic Search Tool Handler
+
+| Task | File | Description |
+|------|------|-------------|
+| T17 | `tools/semantic-search/SemanticSearchToolHandler.cs` | Primary constructor injects `IVectorStore`, `IEmbeddingGenerator<string, Embedding<float>>`, `IOptions<VectorSearchOptions>`, `ILogger<SemanticSearchToolHandler>` |
+| | | `bookstack_semantic_search` tool: validate `query` (not null/whitespace → error string), validate `top_n` (1–50 → error string), embed query, call `SearchAsync`, serialise results as JSON array |
+| | | Returns `"[]"` when index is empty or no results meet `min_score` |
+| | | Returns descriptive string `"Vector search is disabled. Set VectorSearch:Enabled to true to use this tool."` when `!options.Enabled` |
+
+**Tool parameter record**:
+
+```csharp
+internal sealed record SemanticSearchInput(
+    [property: Required] string Query,
+    int TopN = 5,
+    float MinScore = 0.7f);
+```
+
+### Phase 6 — DI Wiring
+
+| Task | File | Description |
+|------|------|-------------|
+| T18 | `api/VectorSearchServiceCollectionExtensions.cs` | `AddVectorSearch(IServiceCollection, IConfiguration)` extension method |
+| | | Registers `IOptions<VectorSearchOptions>` via `Configure<VectorSearchOptions>(configuration.GetSection("VectorSearch"))` |
+| | | If `!options.Enabled`: returns early — no embedding generator, no vector store, no background service registered |
+| | | Selects and registers `IEmbeddingGenerator` per `VectorSearch:EmbeddingProvider` |
+| | | Selects and delegates to the appropriate `Add*VectorStore` extension per `VectorSearch:Database` |
+| | | Registers `VectorIndexSyncService` via `services.AddHostedService<VectorIndexSyncService>()` |
+| T19 | `Program.cs` | Add `builder.Services.AddVectorSearch(builder.Configuration)` after existing service registrations |
+| T20 | `appsettings.json` | Add `VectorSearch` section with all defaults; `Enabled: false` |
+
+**appsettings.json addition**:
+
+```json
+"VectorSearch": {
+  "Enabled": false,
+  "EmbeddingProvider": "Ollama",
+  "Database": "Sqlite",
+  "SyncIntervalHours": 12,
+  "Ollama": {
+    "BaseUrl": "http://localhost:11434",
+    "Model": "nomic-embed-text"
+  },
+  "AzureOpenAI": {
+    "Endpoint": "",
+    "DeploymentName": "",
+    "ApiKey": ""
+  },
+  "Search": {
+    "DefaultTopN": 5,
+    "DefaultMinScore": 0.7
+  }
+}
+```
+
+### Phase 7 — Tests
+
+| Task | Test Class | Coverage |
+|------|-----------|----------|
+| T21 | `VectorIndexSyncServiceTests.cs` | Given unchanged content hash, second sync does not call `GenerateEmbeddingAsync` (Moq `Verify(Times.Never)`) |
+| T22 | `VectorIndexSyncServiceTests.cs` | Given new page, sync calls `UpsertAsync` with correct metadata |
+| T23 | `VectorIndexSyncServiceTests.cs` | Given per-page embedding failure, cycle continues and remaining pages are processed |
+| T24 | `VectorIndexSyncServiceTests.cs` | `SetLastSyncAtAsync` called once per successful cycle |
+| T25 | `SemanticSearchToolHandlerTests.cs` | Empty query returns descriptive error string, does not call embedding generator |
+| T26 | `SemanticSearchToolHandlerTests.cs` | `top_n` = 0 or 51 returns descriptive error string |
+| T27 | `SemanticSearchToolHandlerTests.cs` | Empty vector index returns `"[]"` |
+| T28 | `SemanticSearchToolHandlerTests.cs` | `VectorSearch:Enabled = false` returns feature-disabled message |
+| T29 | `SemanticSearchToolHandlerTests.cs` | Populated index returns JSON array sorted by descending score |
+| T30 | `SemanticSearchToolHandlerTests.cs` | `min_score = 1.0` with sub-threshold results returns `"[]"` |
+| T31 | `InMemoryVectorStoreTests.cs` | `UpsertAsync` then `SearchAsync` returns expected result |
+| T32 | `InMemoryVectorStoreTests.cs` | `GetContentHashAsync` returns null before upsert, hash after |
+| T33 | `BookStackApiClientTests.cs` | `GetPagesUpdatedSinceAsync` sends correct `filter[updated_at:gte]` query parameter |
+
+---
+
+## Key Constraints
+
+- `VectorSearch:Enabled` defaults to `false`. No embedding generator, vector store, or sync
+  service is registered when the feature is disabled. The tool handler still registers (via
+  assembly scan) but returns the feature-disabled message immediately.
+- `IBookStackApiClient.GetPagesUpdatedSinceAsync` uses `count=500` for v1; pagination is deferred.
+- SHA-256 is computed over `page.html_content` (the full HTML field from `GetPageAsync`); the
+  sync service calls `GetPageAsync` for each updated page to retrieve full content.
+- `excerpt` is derived at sync time (first 300 characters of stripped plain text) and stored in
+  the vector store; it is not re-derived at query time.
+- The tool uses the JSON serialisation policy from ADR-0010 (camelCase, snake_case field aliases
+  via `JsonPropertyName` attributes on `VectorSearchResult`).
+- Azure OpenAI API keys MUST NOT appear in log messages. The `VectorIndexSyncService` and
+  `SemanticSearchToolHandler` log only page IDs, counts, and timing — never configuration values.
+- EF Core migrations for `PgVectorStore` and `SqliteVecStore` live in `Data.Postgres` and
+  `Data.Sqlite` respectively, not in the main server project (per ADR-0002).
+
+---
+
+## Commands
+
+### Build
+
+```
+dotnet build /home/mark/github/bookstack-mcp-server-dotnet/BookStack.Mcp.Server.sln --configuration Release
+```
+
+### Tests
+
+```
+dotnet test /home/mark/github/bookstack-mcp-server-dotnet/BookStack.Mcp.Server.sln --verbosity normal
+```
+
+### Lint / Formatting
+
+```
+dotnet format /home/mark/github/bookstack-mcp-server-dotnet/BookStack.Mcp.Server.sln --verify-no-changes
+```
+
+### Local Run (stdio, vector search disabled by default)
+
+```
+dotnet run --project /home/mark/github/bookstack-mcp-server-dotnet/src/BookStack.Mcp.Server
+```
+
+### Local Run (vector search enabled with Ollama)
+
+```
+VECTORSEARCH__ENABLED=true \
+VECTORSEARCH__EMBEDDINGPROVIDER=Ollama \
+VECTORSEARCH__DATABASE=Sqlite \
+dotnet run --project /home/mark/github/bookstack-mcp-server-dotnet/src/BookStack.Mcp.Server
+```

--- a/docs/features/vector-search/spec.md
+++ b/docs/features/vector-search/spec.md
@@ -1,0 +1,349 @@
+# Feature Spec: Vector Search Engine and Semantic Search MCP Tool
+
+**ID**: FEAT-0005
+**Status**: Draft
+**Author**: GitHub Copilot
+**Created**: 2026-04-26
+**Last Updated**: 2026-04-26
+**GitHub Issues**: [#5 — Vector Search Engine](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/5),
+[#11 — Semantic Search MCP Tool](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/11)
+**Parent Epic**: [#3 — Vector Search](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/3)
+**Related ADRs**:
+[ADR-0002](../../architecture/decisions/ADR-0002-solution-structure.md),
+[ADR-0010](../../architecture/decisions/ADR-0010-tool-handler-output-json-policy.md)
+
+---
+
+## Executive Summary
+
+- **Objective**: Add a background vector indexing pipeline and a `bookstack_semantic_search` MCP tool that
+  enables AI agents to discover BookStack pages by semantic meaning rather than exact keyword matches.
+- **Primary user**: MCP clients (LLM agents, Claude Desktop) that need to surface relevant BookStack pages
+  using natural-language queries without knowing precise keywords.
+- **Value delivered**: Semantic discovery of BookStack content beyond keyword search; pages are indexed
+  incrementally in the background, and results include page ID, title, URL, excerpt, and similarity score.
+- **Scope**: Pages only; single embedding per page; Ollama and Azure OpenAI embedding providers; pgvector,
+  SQLite-vec, and in-memory (test) vector stores. Admin status/sync UI (issue #80) is excluded.
+- **Primary success criterion**: `bookstack_semantic_search` returns ranked page results for a natural-language
+  query against a populated index in under 2 seconds, and returns an empty array (not an error) when the
+  index is empty or no results exceed the configured threshold.
+
+---
+
+## Problem Statement
+
+BookStack's existing full-text search (exposed as the `bookstack_search` tool) requires callers to supply
+exact keywords. AI agents working with BookStack content frequently need to ask natural-language questions —
+"how do I reset my password?", "what is our on-call policy?" — without knowing which pages contain relevant
+information or what terminology those pages use.
+
+A vector search engine that embeds page content at indexing time and answers semantic similarity queries at
+search time fills this gap. The data infrastructure (pgvector, SQLite-vec data projects) is already
+scaffolded in the solution; this feature wires up the embedding pipeline, the background sync service, and
+the `bookstack_semantic_search` tool handler to connect them.
+
+## Goals
+
+1. Provide a background service that incrementally indexes BookStack pages as embedding vectors, using a
+   content hash to skip re-embedding pages whose content has not changed since the last sync.
+2. Expose a `bookstack_semantic_search` MCP tool that accepts a natural-language query and returns the
+   top-N most semantically similar pages with their metadata and similarity score.
+3. Support pluggable embedding providers (`IEmbeddingGenerator<string>` via Microsoft.Extensions.AI) and
+   pluggable vector stores (`IVectorStore` abstraction), both selected at startup through configuration.
+4. Degrade gracefully: an empty or unavailable index produces an empty result set, not an exception.
+
+## Non-Goals
+
+- Indexing chapters or books — pages only for v1.
+- Chunking pages into multiple sub-document embeddings — single chunk per page for v1.
+- Admin status bar, `/admin/status`, or `/admin/sync` endpoints — tracked separately as issue #80.
+- SQL Server vector store — the `BookStack.Mcp.Server.Data.SqlServer` project is not targeted by this feature.
+- Modifying or replacing the existing `bookstack_search` keyword-search tool.
+- Hybrid re-ranking (vector + keyword).
+- Deletion sync — pages deleted in BookStack are not removed from the vector index within the same sync
+  cycle; eventual consistency within one polling interval is acceptable for v1.
+- Entra ID / Microsoft Entra authentication for hosted deployments — future concern.
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+1. The system MUST provide a `VectorIndexSyncService` (implementing `IHostedService`) that runs a
+   background polling loop with a configurable interval (default: 12 hours, set via
+   `VectorSearch:SyncIntervalHours`).
+2. On each sync cycle, the service MUST fetch only pages whose `updated_at` field is later than the
+   stored `last_sync_at` timestamp, ensuring incremental-only indexing.
+3. The service MUST compute a SHA-256 hash of each page's HTML content before requesting an embedding;
+   pages whose hash matches the stored `content_hash` MUST be skipped without calling the embedding
+   provider.
+4. The service MUST call `IEmbeddingGenerator<string>` (Microsoft.Extensions.AI) to produce a single
+   embedding vector per page when re-embedding is required.
+5. The service MUST upsert the following metadata alongside each embedding vector: `page_id`, `slug`,
+   `title`, `url`, `updated_at`, and `content_hash`.
+6. The service MUST persist a `last_sync_at` timestamp after each successful sync cycle.
+7. The system MUST define an `IVectorStore` abstraction exposing at minimum `UpsertAsync`,
+   `SearchAsync(vector, topN, minScore)`, `DeleteAsync(pageId)`, `GetContentHashAsync(pageId)`,
+   `GetLastSyncAtAsync`, and `SetLastSyncAtAsync` operations.
+8. The system MUST implement `IVectorStore` for pgvector (PostgreSQL provider,
+   `BookStack.Mcp.Server.Data.Postgres`) and SQLite-vec (SQLite provider,
+   `BookStack.Mcp.Server.Data.Sqlite`).
+9. The system MUST implement an in-memory `IVectorStore` for use in unit tests, requiring no database.
+10. The system MUST support Ollama as an `IEmbeddingGenerator<string>` provider, with configurable base
+    URL (`VectorSearch:Ollama:BaseUrl`, default `http://localhost:11434`) and model name
+    (`VectorSearch:Ollama:Model`, default `nomic-embed-text`).
+11. The system MUST support Azure OpenAI as an `IEmbeddingGenerator<string>` provider, with configurable
+    endpoint, deployment name, and API key sourced from `VectorSearch:AzureOpenAI:*` configuration keys.
+12. The active embedding provider MUST be selected at startup via `VectorSearch:EmbeddingProvider`
+    (`"Ollama"` | `"AzureOpenAI"`).
+13. The system MUST expose a `bookstack_semantic_search` MCP tool accepting:
+    - `query` (string, required) — natural-language search query
+    - `top_n` (int, optional, default 5, range 1–50) — maximum number of results to return
+    - `min_score` (float, optional, default 0.7, range 0.0–1.0) — minimum cosine similarity threshold
+14. `bookstack_semantic_search` MUST embed `query` using the configured `IEmbeddingGenerator<string>`
+    and query `IVectorStore` for the top-N results with score ≥ `min_score`.
+15. `bookstack_semantic_search` MUST return results as a JSON array of objects — sorted by descending
+    `score` — each containing:
+    - `page_id` (int) — BookStack page identifier
+    - `title` (string) — page title
+    - `url` (string) — absolute URL to the page in BookStack
+    - `excerpt` (string) — first 300 characters of the page's plain-text content
+    - `score` (float) — cosine similarity score in the range 0.0–1.0
+16. `bookstack_semantic_search` MUST return an empty JSON array (`[]`) when the vector index contains
+    no entries.
+17. `bookstack_semantic_search` MUST return an empty JSON array (`[]`) when no results satisfy
+    `min_score`, rather than returning an error.
+18. `bookstack_semantic_search` MUST return a descriptive error string (not throw) when `query` is
+    null, empty, or whitespace-only, without calling the embedding provider.
+19. `bookstack_semantic_search` MUST return a descriptive error string (not throw) when `top_n` is
+    outside the range 1–50.
+20. When `VectorSearch:Enabled` is `false`, the application MUST NOT register `VectorIndexSyncService`
+    and `bookstack_semantic_search` MUST return a descriptive "feature disabled" message.
+
+### Non-Functional Requirements
+
+1. `bookstack_semantic_search` MUST return a complete response within 2 seconds for a vector index
+   of up to 10,000 pages on a single-user workload.
+2. The sync service MUST honour the application's `CancellationToken` on shutdown, completing or
+   aborting in-flight operations within 30 seconds.
+3. Errors encountered while processing an individual page during a sync cycle (network failure,
+   embedding provider error) MUST be logged at `Warning` level and MUST NOT abort the cycle or crash
+   the background service; the remaining pages and subsequent cycles proceed normally.
+4. Azure OpenAI API keys and Ollama base URLs MUST be sourced exclusively from `IConfiguration` /
+   `IOptions<T>` and MUST NEVER appear in log output, error strings, or MCP tool responses.
+5. All requests to Azure OpenAI MUST use HTTPS; Ollama requests MAY use HTTP for local deployments.
+6. `IVectorStore` and `IEmbeddingGenerator<string>` MUST be mockable in unit tests without a running
+   database or embedding service.
+
+---
+
+## Design
+
+### Component Diagram
+
+```mermaid
+graph TD
+    subgraph Sync["Background Sync (IHostedService)"]
+        VSS[VectorIndexSyncService]
+    end
+
+    subgraph EmbeddingLayer["Embedding Providers"]
+        IEG["IEmbeddingGenerator(string)\n(Microsoft.Extensions.AI)"]
+        OL[OllamaEmbeddingProvider]
+        AZ[AzureOpenAIEmbeddingProvider]
+    end
+
+    subgraph StoreLayer["Vector Stores"]
+        IVS[IVectorStore]
+        PG["PgVectorStore\n(Data.Postgres)"]
+        SL["SqliteVecStore\n(Data.Sqlite)"]
+        IM["InMemoryVectorStore\n(Tests)"]
+    end
+
+    subgraph ToolLayer["MCP Tool"]
+        SSH[SemanticSearchToolHandler]
+    end
+
+    MC[MCP Client] -->|bookstack_semantic_search| SSH
+    SSH --> IEG
+    SSH --> IVS
+    VSS --> API[IBookStackApiClient]
+    VSS --> IEG
+    VSS --> IVS
+    IEG --> OL
+    IEG --> AZ
+    IVS --> PG
+    IVS --> SL
+    IVS --> IM
+```
+
+### Sync Cycle Sequence
+
+```mermaid
+sequenceDiagram
+    participant Timer
+    participant VSS as VectorIndexSyncService
+    participant API as IBookStackApiClient
+    participant EG  as IEmbeddingGenerator
+    participant VS  as IVectorStore
+
+    Timer->>VSS: Interval elapsed
+    VSS->>VS: GetLastSyncAtAsync()
+    VSS->>API: GetPagesUpdatedSinceAsync(lastSyncAt)
+    loop For each page
+        VSS->>VSS: ComputeSha256(page.html_content)
+        VSS->>VS: GetContentHashAsync(page.id)
+        alt Hash changed or new page
+            VSS->>EG: GenerateEmbeddingAsync(page.html_content)
+            VSS->>VS: UpsertAsync(pageId, metadata, vector)
+        else Hash unchanged
+            VSS->>VSS: Skip — no embedding call
+        end
+    end
+    VSS->>VS: SetLastSyncAtAsync(utcNow)
+```
+
+### API / Tool Interface
+
+| Tool Name                   | Description                                          | Parameters                                                                                      | Returns                  |
+| --------------------------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------ |
+| `bookstack_semantic_search` | Natural-language page search by semantic similarity  | `query: string`, `top_n?: int (1–50, default 5)`, `min_score?: float (0.0–1.0, default 0.7)`   | `SemanticSearchResult[]` |
+
+**`SemanticSearchResult` fields:**
+
+| Field     | Type   | Description                                     |
+| --------- | ------ | ----------------------------------------------- |
+| `page_id` | int    | BookStack page identifier                       |
+| `title`   | string | Page title                                      |
+| `url`     | string | Absolute URL to the page in BookStack           |
+| `excerpt` | string | First 300 characters of page plain-text content |
+| `score`   | float  | Cosine similarity score (0.0–1.0)               |
+
+### Configuration Schema
+
+```json
+{
+  "VectorSearch": {
+    "Enabled": true,
+    "EmbeddingProvider": "Ollama",
+    "SyncIntervalHours": 12,
+    "Ollama": {
+      "BaseUrl": "http://localhost:11434",
+      "Model": "nomic-embed-text"
+    },
+    "AzureOpenAI": {
+      "Endpoint": "",
+      "DeploymentName": "",
+      "ApiKey": ""
+    },
+    "Search": {
+      "DefaultTopN": 5,
+      "DefaultMinScore": 0.7
+    }
+  }
+}
+```
+
+### File Locations
+
+| Artifact                  | Path                                                                             |
+| ------------------------- | -------------------------------------------------------------------------------- |
+| Tool handler              | `src/BookStack.Mcp.Server/tools/semantic-search/SemanticSearchToolHandler.cs`    |
+| Background sync service   | `src/BookStack.Mcp.Server/services/VectorIndexSyncService.cs`                    |
+| Vector store abstraction  | `src/BookStack.Mcp.Server.Data.Abstractions/IVectorStore.cs`                     |
+| pgvector implementation   | `src/BookStack.Mcp.Server.Data.Postgres/PgVectorStore.cs`                        |
+| SQLite-vec implementation | `src/BookStack.Mcp.Server.Data.Sqlite/SqliteVecStore.cs`                         |
+| In-memory implementation  | `tests/BookStack.Mcp.Server.Tests/Fakes/InMemoryVectorStore.cs`                  |
+| Configuration options     | `src/BookStack.Mcp.Server/config/VectorSearchOptions.cs`                         |
+
+---
+
+## Acceptance Criteria
+
+- [ ] Given a populated vector index and a natural-language query, when `bookstack_semantic_search`
+      is called, then it returns a JSON array of up to `top_n` objects each containing `page_id`,
+      `title`, `url`, `excerpt`, and `score`, sorted by descending `score`.
+- [ ] Given an empty vector index, when `bookstack_semantic_search` is called with any query, then
+      it returns `[]` without throwing an exception.
+- [ ] Given an empty or whitespace-only `query`, when `bookstack_semantic_search` is called, then
+      it returns a descriptive error string and does not call the embedding provider.
+- [ ] Given `top_n` outside the range 1–50, when `bookstack_semantic_search` is called, then it
+      returns a descriptive error string.
+- [ ] Given `min_score` of 1.0 and a populated index, when `bookstack_semantic_search` is called,
+      then it returns `[]` without error.
+- [ ] Given `VectorSearch:Enabled` is `false`, when the application starts, then
+      `VectorIndexSyncService` is not registered and `bookstack_semantic_search` returns a
+      descriptive "feature disabled" message.
+- [ ] Given two sync cycles where a page's HTML content has not changed, when the second cycle
+      processes that page, then `IEmbeddingGenerator.GenerateEmbeddingAsync` is not called for that
+      page (verified by mock assertion in unit tests).
+- [ ] Given a sync cycle where the embedding provider returns an error for one page, when the cycle
+      completes, then the remaining pages are processed and the service continues running.
+- [ ] Given an Ollama configuration pointing to a valid local Ollama instance, when an end-to-end
+      sync followed by a `bookstack_semantic_search` call is executed, then results are returned
+      without error.
+
+---
+
+## Compliance Criteria
+
+| ID    | Scenario                              | Input                                                         | Expected Output                                                             |
+| ----- | ------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| CC-01 | Happy path — populated index          | `query="how to reset password"`, `top_n=3`, index has data    | JSON array of ≤3 objects with `page_id`, `title`, `url`, `excerpt`, `score` |
+| CC-02 | Empty index                           | `query="any query"`, index is empty                           | `[]` (empty JSON array, no exception)                                       |
+| CC-03 | Empty query string                    | `query=""`, index populated                                   | Descriptive error string; `GenerateEmbeddingAsync` is not called            |
+| CC-04 | `top_n` out of range                  | `query="test"`, `top_n=100`                                   | Descriptive error string (maximum is 50)                                    |
+| CC-05 | Threshold too high — no results match | `query="test"`, `min_score=1.0`, index populated              | `[]` (empty JSON array, no exception)                                       |
+| CC-06 | Feature disabled                      | `VectorSearch:Enabled=false`, any query                       | Descriptive "feature disabled" error string                                 |
+| CC-07 | Content hash unchanged on second sync | Page content unchanged between two sync cycles                | `GenerateEmbeddingAsync` not called; upsert count is 0 for that page        |
+| CC-08 | Must NOT — credential in logs         | Azure OpenAI API key configured; any sync or search operation | No API key, token, or credential value appears in any structured log entry  |
+
+---
+
+## Invariants
+
+1. The `content_hash` stored in the vector index for a page always reflects the hash of the content that
+   produced the currently stored embedding vector; a mismatch causes re-embedding on the next cycle.
+2. `bookstack_semantic_search` never throws an unhandled exception; all error conditions return a
+   descriptive string consistent with ADR-0010.
+3. The background sync service never propagates a single-page embedding failure to the outer polling
+   loop; per-page failures are isolated and logged, and the remaining pages in the cycle are processed.
+4. Embedding provider credentials (API keys, base URLs) never appear in log messages, MCP tool
+   output, or error strings under any code path.
+
+---
+
+## Security Considerations
+
+- Azure OpenAI API keys and Ollama base URLs MUST be read from `IConfiguration` (environment variables,
+  secrets manager, or Azure Key Vault) and MUST NOT be hardcoded or committed to source control.
+- Credentials MUST NOT appear in structured log output at any severity level.
+- The `excerpt` field returned by `bookstack_semantic_search` contains up to 300 characters of
+  BookStack page content. Access control is assumed to be enforced by the BookStack API token already
+  used by the server — the same trust boundary as all other content-returning tools.
+- Input validation on `query`, `top_n`, and `min_score` MUST occur at the tool handler boundary
+  before any downstream call is made.
+- Ollama requests are local-only (HTTP to localhost); TLS is not required. Azure OpenAI requests
+  MUST use HTTPS.
+- The `excerpt` field MUST be truncated to a maximum of 300 characters at the tool handler layer,
+  not delegated to the caller.
+
+---
+
+## Open Questions
+
+*(None — all design decisions were resolved in the specification brief.)*
+
+---
+
+## Out of Scope
+
+- Chapter-level and book-level embeddings (v2 consideration).
+- Sub-page chunking into multiple embeddings per page (v2 consideration).
+- SQL Server vector store implementation.
+- Admin status/sync UI, `/admin/status`, and `/admin/sync` endpoints (issue #80).
+- Entra ID / Microsoft Entra authentication for hosted deployments.
+- Hybrid search (vector similarity + keyword re-ranking).
+- Within-cycle deletion sync — pages deleted in BookStack persist in the vector index until the next
+  sync cycle detects them as absent; this eventual consistency is acceptable for v1.

--- a/docs/features/vector-search/tasks.md
+++ b/docs/features/vector-search/tasks.md
@@ -95,7 +95,7 @@
 **Tracks**: Part of #11
 **Depends on**: #81, #82
 
-- [ ] Create `src/BookStack.Mcp.Server/tools/semantic-search/SemanticSearchToolHandler.cs`
+- [x] Create `src/BookStack.Mcp.Server/tools/semantic-search/SemanticSearchToolHandler.cs`
 
 ---
 
@@ -105,10 +105,10 @@
 **Tracks**: Part of #5
 **Depends on**: #81, #82, #85, #86, #87, #88
 
-- [ ] Create `src/BookStack.Mcp.Server/api/VectorSearchServiceCollectionExtensions.cs`
-- [ ] Add `AddVectorSearch` call to `src/BookStack.Mcp.Server/Program.cs`
-- [ ] Add `VectorSearch` section to `src/BookStack.Mcp.Server/appsettings.json`
-- [ ] Add `Microsoft.Extensions.AI`, `Microsoft.Extensions.AI.Ollama`, `Azure.AI.OpenAI` to `BookStack.Mcp.Server.csproj`
+- [x] Create `src/BookStack.Mcp.Server/api/VectorSearchServiceCollectionExtensions.cs`
+- [x] Add `AddVectorSearch` call to `src/BookStack.Mcp.Server/Program.cs`
+- [x] Add `VectorSearch` section to `src/BookStack.Mcp.Server/appsettings.json`
+- [x] Add `Microsoft.Extensions.AI`, `Microsoft.Extensions.AI.Ollama`, `Microsoft.Extensions.AI.OpenAI`, `Azure.AI.OpenAI` to `BookStack.Mcp.Server.csproj`
 
 ---
 

--- a/docs/features/vector-search/tasks.md
+++ b/docs/features/vector-search/tasks.md
@@ -118,9 +118,9 @@
 **Tracks**: Part of #5, Part of #11
 **Depends on**: #84, #87, #88
 
-- [ ] Create `tests/BookStack.Mcp.Server.Tests/VectorSearch/VectorIndexSyncServiceTests.cs`
-- [ ] Create `tests/BookStack.Mcp.Server.Tests/VectorSearch/SemanticSearchToolHandlerTests.cs`
-- [ ] Create `tests/BookStack.Mcp.Server.Tests/VectorSearch/VectorSearchIntegrationTests.cs`
+- [x] Create `tests/BookStack.Mcp.Server.Tests/VectorSearch/VectorIndexSyncServiceTests.cs`
+- [x] Create `tests/BookStack.Mcp.Server.Tests/VectorSearch/SemanticSearchToolHandlerTests.cs`
+- [x] Create `tests/BookStack.Mcp.Server.Tests/VectorSearch/VectorSearchIntegrationTests.cs`
 
 ---
 

--- a/docs/features/vector-search/tasks.md
+++ b/docs/features/vector-search/tasks.md
@@ -57,7 +57,7 @@
 **Tracks**: Part of #5
 **Depends on**: #82
 
-- [ ] [P] Add `Microsoft.SemanticKernel.Connectors.Sqlite 1.51.0-preview` and `Microsoft.EntityFrameworkCore.Sqlite 10.*` to `BookStack.Mcp.Server.Data.Sqlite.csproj`
+- [ ] [P] Add `Microsoft.SemanticKernel.Connectors.SqliteVec 1.74.0-preview` and `Microsoft.EntityFrameworkCore.Sqlite 10.*` to `BookStack.Mcp.Server.Data.Sqlite.csproj`
 - [ ] [P] Create `src/BookStack.Mcp.Server.Data.Sqlite/VectorPageRecord.cs` (SK record type with `[VectorStoreRecordKey]` / `[VectorStoreRecordData]` / `[VectorStoreRecordVector]` attributes)
 - [ ] [P] Create `src/BookStack.Mcp.Server.Data.Sqlite/SyncMetadataDbContext.cs` (EF Core; `sync_metadata` table only)
 - [ ] [P] Create `src/BookStack.Mcp.Server.Data.Sqlite/SqliteVectorStore.cs` (wraps SK `SqliteVectorStore`; implements `IVectorStore`)
@@ -85,7 +85,7 @@
 **Tracks**: Part of #5
 **Depends on**: #81, #82, #83
 
-- [ ] Create `src/BookStack.Mcp.Server/services/VectorIndexSyncService.cs`
+- [x] Create `src/BookStack.Mcp.Server/services/VectorIndexSyncService.cs`
 
 ---
 

--- a/docs/features/vector-search/tasks.md
+++ b/docs/features/vector-search/tasks.md
@@ -1,0 +1,140 @@
+# Tasks: Vector Search Engine and Semantic Search MCP Tool (FEAT-0005)
+
+**Feature**: Vector Search Engine and Semantic Search MCP Tool
+**Spec**: [docs/features/vector-search/spec.md](spec.md)
+**Plan**: [docs/features/vector-search/plan.md](plan.md)
+**GitHub Issues**: [#5 — Vector Search Engine](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/5),
+[#11 — Semantic Search MCP Tool](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/11)
+**Parent Epic**: [#3 — Vector Search](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/3)
+**Status**: Ready for Implementation
+**Date**: 2026-04-26
+
+---
+
+## Phase 1 — VectorSearchOptions configuration types
+
+**Issue**: [#81](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/81)
+**Tracks**: Part of #5
+
+- [ ] Create `src/BookStack.Mcp.Server/config/VectorSearchOptions.cs` with `VectorSearchOptions`, `OllamaEmbeddingOptions`, `AzureOpenAIEmbeddingOptions`, `VectorSearchDefaults`
+
+---
+
+## Phase 2 — IVectorStore abstraction and supporting types
+
+**Issue**: [#82](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/82)
+**Tracks**: Part of #5
+
+- [ ] Create `src/BookStack.Mcp.Server.Data.Abstractions/IVectorStore.cs`
+- [ ] Create `src/BookStack.Mcp.Server.Data.Abstractions/VectorPageEntry.cs`
+- [ ] Create `src/BookStack.Mcp.Server.Data.Abstractions/VectorSearchResult.cs`
+
+---
+
+## Phase 3 — GetPagesUpdatedSinceAsync API client extension
+
+**Issue**: [#83](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/83)
+**Tracks**: Part of #5
+
+- [ ] Add `GetPagesUpdatedSinceAsync` to `src/BookStack.Mcp.Server/api/IBookStackApiClient.cs`
+- [ ] Implement in `src/BookStack.Mcp.Server/api/BookStackApiClient.Pages.cs`
+
+---
+
+## Phase 4 — InMemoryVectorStore (test fake)
+
+**Issue**: [#84](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/84)
+**Tracks**: Part of #5
+**Depends on**: #82
+
+- [ ] [P] Create `tests/BookStack.Mcp.Server.Tests/Fakes/InMemoryVectorStore.cs`
+
+---
+
+## Phase 5 — SqliteVectorStore (SK SQLite connector provider)
+
+**Issue**: [#85](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/85)
+**Tracks**: Part of #5
+**Depends on**: #82
+
+- [ ] [P] Add `Microsoft.SemanticKernel.Connectors.Sqlite 1.51.0-preview` and `Microsoft.EntityFrameworkCore.Sqlite 10.*` to `BookStack.Mcp.Server.Data.Sqlite.csproj`
+- [ ] [P] Create `src/BookStack.Mcp.Server.Data.Sqlite/VectorPageRecord.cs` (SK record type with `[VectorStoreRecordKey]` / `[VectorStoreRecordData]` / `[VectorStoreRecordVector]` attributes)
+- [ ] [P] Create `src/BookStack.Mcp.Server.Data.Sqlite/SyncMetadataDbContext.cs` (EF Core; `sync_metadata` table only)
+- [ ] [P] Create `src/BookStack.Mcp.Server.Data.Sqlite/SqliteVectorStore.cs` (wraps SK `SqliteVectorStore`; implements `IVectorStore`)
+- [ ] [P] Create `src/BookStack.Mcp.Server.Data.Sqlite/SqliteVectorStoreServiceCollectionExtensions.cs`
+
+---
+
+## Phase 6 — PgVectorStore (pgvector / PostgreSQL provider)
+
+**Issue**: [#86](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/86)
+**Tracks**: Part of #5
+**Depends on**: #82
+
+- [ ] [P] Add `Pgvector` NuGet reference to `BookStack.Mcp.Server.Data.Postgres.csproj`
+- [ ] [P] Create `src/BookStack.Mcp.Server.Data.Postgres/VectorPageRecord.cs`
+- [ ] [P] Create `src/BookStack.Mcp.Server.Data.Postgres/VectorDbContext.cs`
+- [ ] [P] Create `src/BookStack.Mcp.Server.Data.Postgres/PgVectorStore.cs`
+- [ ] [P] Create `src/BookStack.Mcp.Server.Data.Postgres/PostgresVectorStoreServiceCollectionExtensions.cs`
+
+---
+
+## Phase 7 — VectorIndexSyncService (background sync)
+
+**Issue**: [#87](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/87)
+**Tracks**: Part of #5
+**Depends on**: #81, #82, #83
+
+- [ ] Create `src/BookStack.Mcp.Server/services/VectorIndexSyncService.cs`
+
+---
+
+## Phase 8 — SemanticSearchToolHandler (bookstack_semantic_search tool)
+
+**Issue**: [#88](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/88)
+**Tracks**: Part of #11
+**Depends on**: #81, #82
+
+- [ ] Create `src/BookStack.Mcp.Server/tools/semantic-search/SemanticSearchToolHandler.cs`
+
+---
+
+## Phase 9 — DI wiring, appsettings.json, and NuGet references
+
+**Issue**: [#89](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/89)
+**Tracks**: Part of #5
+**Depends on**: #81, #82, #85, #86, #87, #88
+
+- [ ] Create `src/BookStack.Mcp.Server/api/VectorSearchServiceCollectionExtensions.cs`
+- [ ] Add `AddVectorSearch` call to `src/BookStack.Mcp.Server/Program.cs`
+- [ ] Add `VectorSearch` section to `src/BookStack.Mcp.Server/appsettings.json`
+- [ ] Add `Microsoft.Extensions.AI`, `Microsoft.Extensions.AI.Ollama`, `Azure.AI.OpenAI` to `BookStack.Mcp.Server.csproj`
+
+---
+
+## Phase 10 — TUnit tests
+
+**Issue**: [#90](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/90)
+**Tracks**: Part of #5, Part of #11
+**Depends on**: #84, #87, #88
+
+- [ ] Create `tests/BookStack.Mcp.Server.Tests/VectorSearch/VectorIndexSyncServiceTests.cs`
+- [ ] Create `tests/BookStack.Mcp.Server.Tests/VectorSearch/SemanticSearchToolHandlerTests.cs`
+- [ ] Create `tests/BookStack.Mcp.Server.Tests/VectorSearch/VectorSearchIntegrationTests.cs`
+
+---
+
+## Issue Summary
+
+| Phase | Issue | Title | Depends on |
+|-------|-------|-------|------------|
+| 1 | [#81](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/81) | VectorSearchOptions configuration types | — |
+| 2 | [#82](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/82) | IVectorStore abstraction and supporting types | — |
+| 3 | [#83](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/83) | GetPagesUpdatedSinceAsync API client extension | — |
+| 4 | [#84](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/84) | InMemoryVectorStore (test fake) | #82 |
+| 5 | [#85](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/85) | SqliteVectorStore (SK SQLite connector provider) | #82 |
+| 6 | [#86](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/86) | PgVectorStore (pgvector / PostgreSQL provider) | #82 |
+| 7 | [#87](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/87) | VectorIndexSyncService (background sync) | #81, #82, #83 |
+| 8 | [#88](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/88) | SemanticSearchToolHandler | #81, #82 |
+| 9 | [#89](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/89) | DI wiring, appsettings.json, NuGet refs | #81, #82, #85, #86, #87, #88 |
+| 10 | [#90](https://github.com/MarkZither/bookstack-mcp-server-dotnet/issues/90) | TUnit tests | #84, #87, #88 |

--- a/src/BookStack.Mcp.Server.Data.Abstractions/IVectorStore.cs
+++ b/src/BookStack.Mcp.Server.Data.Abstractions/IVectorStore.cs
@@ -1,0 +1,20 @@
+namespace BookStack.Mcp.Server.Data.Abstractions;
+
+public interface IVectorStore
+{
+    Task UpsertAsync(VectorPageEntry entry, ReadOnlyMemory<float> vector, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<VectorSearchResult>> SearchAsync(
+        ReadOnlyMemory<float> queryVector,
+        int topN,
+        float minScore,
+        CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(int pageId, CancellationToken cancellationToken = default);
+
+    Task<string?> GetContentHashAsync(int pageId, CancellationToken cancellationToken = default);
+
+    Task<DateTimeOffset?> GetLastSyncAtAsync(CancellationToken cancellationToken = default);
+
+    Task SetLastSyncAtAsync(DateTimeOffset timestamp, CancellationToken cancellationToken = default);
+}

--- a/src/BookStack.Mcp.Server.Data.Abstractions/VectorPageEntry.cs
+++ b/src/BookStack.Mcp.Server.Data.Abstractions/VectorPageEntry.cs
@@ -1,0 +1,12 @@
+namespace BookStack.Mcp.Server.Data.Abstractions;
+
+public sealed class VectorPageEntry
+{
+    public int PageId { get; init; }
+    public string Slug { get; init; } = string.Empty;
+    public string Title { get; init; } = string.Empty;
+    public string Url { get; init; } = string.Empty;
+    public string Excerpt { get; init; } = string.Empty;
+    public DateTimeOffset UpdatedAt { get; init; }
+    public string ContentHash { get; init; } = string.Empty;
+}

--- a/src/BookStack.Mcp.Server.Data.Abstractions/VectorSearchResult.cs
+++ b/src/BookStack.Mcp.Server.Data.Abstractions/VectorSearchResult.cs
@@ -1,0 +1,10 @@
+namespace BookStack.Mcp.Server.Data.Abstractions;
+
+public sealed class VectorSearchResult
+{
+    public int PageId { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string Url { get; init; } = string.Empty;
+    public string Excerpt { get; init; } = string.Empty;
+    public float Score { get; init; }
+}

--- a/src/BookStack.Mcp.Server.Data.Postgres/BookStack.Mcp.Server.Data.Postgres.csproj
+++ b/src/BookStack.Mcp.Server.Data.Postgres/BookStack.Mcp.Server.Data.Postgres.csproj
@@ -9,7 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Npgsql" Version="10.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.*" />
+    <PackageReference Include="Pgvector" Version="0.3.2" />
+    <PackageReference Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BookStack.Mcp.Server.Data.Postgres/PgVectorStore.cs
+++ b/src/BookStack.Mcp.Server.Data.Postgres/PgVectorStore.cs
@@ -1,0 +1,145 @@
+using BookStack.Mcp.Server.Data.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Pgvector;
+using Pgvector.EntityFrameworkCore;
+
+namespace BookStack.Mcp.Server.Data.Postgres;
+
+public sealed class PgVectorStore : IVectorStore
+{
+    private const string LastSyncKey = "last_sync_at";
+
+    private readonly IDbContextFactory<VectorDbContext> _factory;
+
+    public PgVectorStore(IDbContextFactory<VectorDbContext> factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task UpsertAsync(VectorPageEntry entry, ReadOnlyMemory<float> vector, CancellationToken cancellationToken = default)
+    {
+#pragma warning disable CA2007
+        await using var db = await _factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+#pragma warning restore CA2007
+        var existing = await db.PageVectors.FindAsync([entry.PageId], cancellationToken).ConfigureAwait(false);
+        if (existing is null)
+        {
+            db.PageVectors.Add(MapToRecord(entry, vector));
+        }
+        else
+        {
+            existing.Slug = entry.Slug;
+            existing.Title = entry.Title;
+            existing.Url = entry.Url;
+            existing.Excerpt = entry.Excerpt;
+            existing.UpdatedAt = entry.UpdatedAt;
+            existing.ContentHash = entry.ContentHash;
+            existing.Embedding = new Vector(vector.ToArray());
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<VectorSearchResult>> SearchAsync(
+        ReadOnlyMemory<float> queryVector,
+        int topN,
+        float minScore,
+        CancellationToken cancellationToken = default)
+    {
+#pragma warning disable CA2007
+        await using var db = await _factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+#pragma warning restore CA2007
+        var query = new Vector(queryVector.ToArray());
+
+        var rows = await db.PageVectors
+            .OrderBy(p => p.Embedding!.CosineDistance(query))
+            .Take(topN)
+            .Select(p => new
+            {
+                p.PageId,
+                p.Title,
+                p.Url,
+                p.Excerpt,
+                Score = 1f - (float)p.Embedding!.CosineDistance(query),
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return rows
+            .Where(r => r.Score >= minScore)
+            .Select(r => new VectorSearchResult
+            {
+                PageId = r.PageId,
+                Title = r.Title,
+                Url = r.Url,
+                Excerpt = r.Excerpt,
+                Score = r.Score,
+            })
+            .ToList();
+    }
+
+    public async Task DeleteAsync(int pageId, CancellationToken cancellationToken = default)
+    {
+#pragma warning disable CA2007
+        await using var db = await _factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+#pragma warning restore CA2007
+        await db.PageVectors.Where(p => p.PageId == pageId).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<string?> GetContentHashAsync(int pageId, CancellationToken cancellationToken = default)
+    {
+#pragma warning disable CA2007
+        await using var db = await _factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+#pragma warning restore CA2007
+        return await db.PageVectors
+            .Where(p => p.PageId == pageId)
+            .Select(p => p.ContentHash)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<DateTimeOffset?> GetLastSyncAtAsync(CancellationToken cancellationToken = default)
+    {
+#pragma warning disable CA2007
+        await using var db = await _factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+#pragma warning restore CA2007
+        var row = await db.SyncMetadata.FirstOrDefaultAsync(r => r.Key == LastSyncKey, cancellationToken).ConfigureAwait(false);
+        if (row is null || !DateTimeOffset.TryParse(row.Value, out var ts))
+        {
+            return null;
+        }
+
+        return ts;
+    }
+
+    public async Task SetLastSyncAtAsync(DateTimeOffset timestamp, CancellationToken cancellationToken = default)
+    {
+#pragma warning disable CA2007
+        await using var db = await _factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+#pragma warning restore CA2007
+        var row = await db.SyncMetadata.FirstOrDefaultAsync(r => r.Key == LastSyncKey, cancellationToken).ConfigureAwait(false);
+        if (row is null)
+        {
+            db.SyncMetadata.Add(new SyncMetadataRecord { Key = LastSyncKey, Value = timestamp.ToString("O") });
+        }
+        else
+        {
+            row.Value = timestamp.ToString("O");
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static VectorPageRecord MapToRecord(VectorPageEntry entry, ReadOnlyMemory<float> vector) =>
+        new()
+        {
+            PageId = entry.PageId,
+            Slug = entry.Slug,
+            Title = entry.Title,
+            Url = entry.Url,
+            Excerpt = entry.Excerpt,
+            UpdatedAt = entry.UpdatedAt,
+            ContentHash = entry.ContentHash,
+            Embedding = new Vector(vector.ToArray()),
+        };
+}

--- a/src/BookStack.Mcp.Server.Data.Postgres/PgVectorStore.cs
+++ b/src/BookStack.Mcp.Server.Data.Postgres/PgVectorStore.cs
@@ -7,7 +7,7 @@ namespace BookStack.Mcp.Server.Data.Postgres;
 
 public sealed class PgVectorStore : IVectorStore
 {
-    private const string LastSyncKey = "last_sync_at";
+    private const string _lastSyncKey = "last_sync_at";
 
     private readonly IDbContextFactory<VectorDbContext> _factory;
 
@@ -103,7 +103,7 @@ public sealed class PgVectorStore : IVectorStore
 #pragma warning disable CA2007
         await using var db = await _factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 #pragma warning restore CA2007
-        var row = await db.SyncMetadata.FirstOrDefaultAsync(r => r.Key == LastSyncKey, cancellationToken).ConfigureAwait(false);
+        var row = await db.SyncMetadata.FirstOrDefaultAsync(r => r.Key == _lastSyncKey, cancellationToken).ConfigureAwait(false);
         if (row is null || !DateTimeOffset.TryParse(row.Value, out var ts))
         {
             return null;
@@ -117,10 +117,10 @@ public sealed class PgVectorStore : IVectorStore
 #pragma warning disable CA2007
         await using var db = await _factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 #pragma warning restore CA2007
-        var row = await db.SyncMetadata.FirstOrDefaultAsync(r => r.Key == LastSyncKey, cancellationToken).ConfigureAwait(false);
+        var row = await db.SyncMetadata.FirstOrDefaultAsync(r => r.Key == _lastSyncKey, cancellationToken).ConfigureAwait(false);
         if (row is null)
         {
-            db.SyncMetadata.Add(new SyncMetadataRecord { Key = LastSyncKey, Value = timestamp.ToString("O") });
+            db.SyncMetadata.Add(new SyncMetadataRecord { Key = _lastSyncKey, Value = timestamp.ToString("O") });
         }
         else
         {

--- a/src/BookStack.Mcp.Server.Data.Postgres/PostgresVectorStoreServiceCollectionExtensions.cs
+++ b/src/BookStack.Mcp.Server.Data.Postgres/PostgresVectorStoreServiceCollectionExtensions.cs
@@ -1,0 +1,23 @@
+using BookStack.Mcp.Server.Data.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+
+namespace BookStack.Mcp.Server.Data.Postgres;
+
+public static class PostgresVectorStoreServiceCollectionExtensions
+{
+    public static IServiceCollection AddPostgresVectorStore(
+        this IServiceCollection services,
+        string connectionString)
+    {
+        services.AddDbContextFactory<VectorDbContext>(options =>
+            options.UseNpgsql(
+                connectionString,
+                npgsql => npgsql.UseVector()));
+
+        services.AddSingleton<IVectorStore, PgVectorStore>();
+
+        return services;
+    }
+}

--- a/src/BookStack.Mcp.Server.Data.Postgres/VectorDbContext.cs
+++ b/src/BookStack.Mcp.Server.Data.Postgres/VectorDbContext.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace BookStack.Mcp.Server.Data.Postgres;
+
+public sealed class VectorDbContext : DbContext
+{
+    public DbSet<VectorPageRecord> PageVectors => Set<VectorPageRecord>();
+    public DbSet<SyncMetadataRecord> SyncMetadata => Set<SyncMetadataRecord>();
+
+    public VectorDbContext(DbContextOptions<VectorDbContext> options)
+        : base(options)
+    {
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasPostgresExtension("vector");
+        modelBuilder.ApplyConfiguration(new VectorPageRecordConfiguration());
+        modelBuilder.Entity<SyncMetadataRecord>(b =>
+        {
+            b.ToTable("sync_metadata");
+            b.HasKey(e => e.Key);
+            b.Property(e => e.Key).HasMaxLength(64);
+            b.Property(e => e.Value).HasMaxLength(256);
+        });
+    }
+}
+
+public sealed class SyncMetadataRecord
+{
+    public string Key { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+}

--- a/src/BookStack.Mcp.Server.Data.Postgres/VectorPageRecord.cs
+++ b/src/BookStack.Mcp.Server.Data.Postgres/VectorPageRecord.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Pgvector;
+
+namespace BookStack.Mcp.Server.Data.Postgres;
+
+public sealed class VectorPageRecord
+{
+    public int PageId { get; set; }
+    public string Slug { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Url { get; set; } = string.Empty;
+    public string Excerpt { get; set; } = string.Empty;
+    public DateTimeOffset UpdatedAt { get; set; }
+    public string ContentHash { get; set; } = string.Empty;
+    public Vector? Embedding { get; set; }
+}
+
+public sealed class VectorPageRecordConfiguration : IEntityTypeConfiguration<VectorPageRecord>
+{
+    public void Configure(EntityTypeBuilder<VectorPageRecord> builder)
+    {
+        builder.ToTable("page_vectors");
+        builder.HasKey(e => e.PageId);
+        builder.Property(e => e.Slug).HasMaxLength(512);
+        builder.Property(e => e.Title).HasMaxLength(512);
+        builder.Property(e => e.Url).HasMaxLength(1024);
+        builder.Property(e => e.Excerpt).HasMaxLength(2048);
+        builder.Property(e => e.ContentHash).HasMaxLength(64);
+        builder.Property(e => e.Embedding).HasColumnType("vector(768)");
+
+        builder.HasIndex(e => e.Embedding)
+            .HasMethod("hnsw")
+            .HasOperators("vector_cosine_ops");
+    }
+}

--- a/src/BookStack.Mcp.Server.Data.Sqlite/BookStack.Mcp.Server.Data.Sqlite.csproj
+++ b/src/BookStack.Mcp.Server.Data.Sqlite/BookStack.Mcp.Server.Data.Sqlite.csproj
@@ -9,7 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.VectorData.Abstractions" Version="10.1.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.SqliteVec" Version="1.74.0-preview" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BookStack.Mcp.Server.Data.Sqlite/SqliteVectorStoreImpl.cs
+++ b/src/BookStack.Mcp.Server.Data.Sqlite/SqliteVectorStoreImpl.cs
@@ -1,0 +1,114 @@
+using BookStack.Mcp.Server.Data.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.SqliteVec;
+
+namespace BookStack.Mcp.Server.Data.Sqlite;
+
+public sealed class SqliteVectorStore : IVectorStore
+{
+    private const string CollectionName = "page_vectors";
+    private const string LastSyncKey = "last_sync_at";
+
+    private readonly SqliteCollection<int, VectorPageRecord> _collection;
+    private readonly IDbContextFactory<SyncMetadataDbContext> _metaFactory;
+
+    public SqliteVectorStore(
+        string connectionString,
+        IDbContextFactory<SyncMetadataDbContext> metaFactory)
+    {
+        _collection = new SqliteCollection<int, VectorPageRecord>(connectionString, CollectionName);
+        _metaFactory = metaFactory;
+    }
+
+    public async Task UpsertAsync(VectorPageEntry entry, ReadOnlyMemory<float> vector, CancellationToken cancellationToken = default)
+    {
+        await _collection.EnsureCollectionExistsAsync(cancellationToken).ConfigureAwait(false);
+        var record = new VectorPageRecord
+        {
+            PageId = entry.PageId,
+            Slug = entry.Slug,
+            Title = entry.Title,
+            Url = entry.Url,
+            Excerpt = entry.Excerpt,
+            UpdatedAtTicks = entry.UpdatedAt.UtcTicks,
+            ContentHash = entry.ContentHash,
+            Embedding = vector,
+        };
+        await _collection.UpsertAsync(record, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<VectorSearchResult>> SearchAsync(
+        ReadOnlyMemory<float> queryVector,
+        int topN,
+        float minScore,
+        CancellationToken cancellationToken = default)
+    {
+        await _collection.EnsureCollectionExistsAsync(cancellationToken).ConfigureAwait(false);
+
+        var results = new List<VectorSearchResult>();
+        await foreach (var r in _collection.SearchAsync(queryVector, topN, cancellationToken: cancellationToken).ConfigureAwait(false))
+        {
+            if (r.Score < minScore)
+            {
+                continue;
+            }
+
+            results.Add(new VectorSearchResult
+            {
+                PageId = r.Record.PageId,
+                Title = r.Record.Title,
+                Url = r.Record.Url,
+                Excerpt = r.Record.Excerpt,
+                Score = (float)(r.Score ?? 0),
+            });
+        }
+
+        return results;
+    }
+
+    public async Task DeleteAsync(int pageId, CancellationToken cancellationToken = default)
+    {
+        await _collection.EnsureCollectionExistsAsync(cancellationToken).ConfigureAwait(false);
+        await _collection.DeleteAsync(pageId, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<string?> GetContentHashAsync(int pageId, CancellationToken cancellationToken = default)
+    {
+        await _collection.EnsureCollectionExistsAsync(cancellationToken).ConfigureAwait(false);
+        var record = await _collection.GetAsync(pageId, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return record?.ContentHash;
+    }
+
+    public async Task<DateTimeOffset?> GetLastSyncAtAsync(CancellationToken cancellationToken = default)
+    {
+#pragma warning disable CA2007
+        await using var db = await _metaFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+#pragma warning restore CA2007
+        var row = await db.SyncMetadata.FirstOrDefaultAsync(r => r.Key == LastSyncKey, cancellationToken).ConfigureAwait(false);
+        if (row is null || !DateTimeOffset.TryParse(row.Value, out var ts))
+        {
+            return null;
+        }
+
+        return ts;
+    }
+
+    public async Task SetLastSyncAtAsync(DateTimeOffset timestamp, CancellationToken cancellationToken = default)
+    {
+#pragma warning disable CA2007
+        await using var db = await _metaFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+#pragma warning restore CA2007
+        var row = await db.SyncMetadata.FirstOrDefaultAsync(r => r.Key == LastSyncKey, cancellationToken).ConfigureAwait(false);
+        if (row is null)
+        {
+            db.SyncMetadata.Add(new SyncMetadataRecord { Key = LastSyncKey, Value = timestamp.ToString("O") });
+        }
+        else
+        {
+            row.Value = timestamp.ToString("O");
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/BookStack.Mcp.Server.Data.Sqlite/SqliteVectorStoreImpl.cs
+++ b/src/BookStack.Mcp.Server.Data.Sqlite/SqliteVectorStoreImpl.cs
@@ -7,8 +7,8 @@ namespace BookStack.Mcp.Server.Data.Sqlite;
 
 public sealed class SqliteVectorStore : IVectorStore
 {
-    private const string CollectionName = "page_vectors";
-    private const string LastSyncKey = "last_sync_at";
+    private const string _collectionName = "page_vectors";
+    private const string _lastSyncKey = "last_sync_at";
 
     private readonly SqliteCollection<int, VectorPageRecord> _collection;
     private readonly IDbContextFactory<SyncMetadataDbContext> _metaFactory;
@@ -17,7 +17,7 @@ public sealed class SqliteVectorStore : IVectorStore
         string connectionString,
         IDbContextFactory<SyncMetadataDbContext> metaFactory)
     {
-        _collection = new SqliteCollection<int, VectorPageRecord>(connectionString, CollectionName);
+        _collection = new SqliteCollection<int, VectorPageRecord>(connectionString, _collectionName);
         _metaFactory = metaFactory;
     }
 
@@ -85,7 +85,7 @@ public sealed class SqliteVectorStore : IVectorStore
 #pragma warning disable CA2007
         await using var db = await _metaFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 #pragma warning restore CA2007
-        var row = await db.SyncMetadata.FirstOrDefaultAsync(r => r.Key == LastSyncKey, cancellationToken).ConfigureAwait(false);
+        var row = await db.SyncMetadata.FirstOrDefaultAsync(r => r.Key == _lastSyncKey, cancellationToken).ConfigureAwait(false);
         if (row is null || !DateTimeOffset.TryParse(row.Value, out var ts))
         {
             return null;
@@ -99,10 +99,10 @@ public sealed class SqliteVectorStore : IVectorStore
 #pragma warning disable CA2007
         await using var db = await _metaFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 #pragma warning restore CA2007
-        var row = await db.SyncMetadata.FirstOrDefaultAsync(r => r.Key == LastSyncKey, cancellationToken).ConfigureAwait(false);
+        var row = await db.SyncMetadata.FirstOrDefaultAsync(r => r.Key == _lastSyncKey, cancellationToken).ConfigureAwait(false);
         if (row is null)
         {
-            db.SyncMetadata.Add(new SyncMetadataRecord { Key = LastSyncKey, Value = timestamp.ToString("O") });
+            db.SyncMetadata.Add(new SyncMetadataRecord { Key = _lastSyncKey, Value = timestamp.ToString("O") });
         }
         else
         {

--- a/src/BookStack.Mcp.Server.Data.Sqlite/SqliteVectorStoreServiceCollectionExtensions.cs
+++ b/src/BookStack.Mcp.Server.Data.Sqlite/SqliteVectorStoreServiceCollectionExtensions.cs
@@ -1,0 +1,24 @@
+using BookStack.Mcp.Server.Data.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BookStack.Mcp.Server.Data.Sqlite;
+
+public static class SqliteVectorStoreServiceCollectionExtensions
+{
+    public static IServiceCollection AddSqliteVectorStore(
+        this IServiceCollection services,
+        string connectionString)
+    {
+        services.AddDbContextFactory<SyncMetadataDbContext>(options =>
+            options.UseSqlite(connectionString));
+
+        services.AddSingleton<IVectorStore>(sp =>
+        {
+            var factory = sp.GetRequiredService<IDbContextFactory<SyncMetadataDbContext>>();
+            return new SqliteVectorStore(connectionString, factory);
+        });
+
+        return services;
+    }
+}

--- a/src/BookStack.Mcp.Server.Data.Sqlite/SyncMetadataDbContext.cs
+++ b/src/BookStack.Mcp.Server.Data.Sqlite/SyncMetadataDbContext.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace BookStack.Mcp.Server.Data.Sqlite;
+
+public sealed class SyncMetadataDbContext : DbContext
+{
+    public DbSet<SyncMetadataRecord> SyncMetadata => Set<SyncMetadataRecord>();
+
+    public SyncMetadataDbContext(DbContextOptions<SyncMetadataDbContext> options)
+        : base(options)
+    {
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<SyncMetadataRecord>(b =>
+        {
+            b.ToTable("sync_metadata");
+            b.HasKey(e => e.Key);
+            b.Property(e => e.Key).HasMaxLength(64);
+            b.Property(e => e.Value).HasMaxLength(256);
+        });
+    }
+}
+
+public sealed class SyncMetadataRecord
+{
+    public string Key { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+}

--- a/src/BookStack.Mcp.Server.Data.Sqlite/VectorPageRecord.cs
+++ b/src/BookStack.Mcp.Server.Data.Sqlite/VectorPageRecord.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.VectorData;
+
+namespace BookStack.Mcp.Server.Data.Sqlite;
+
+public sealed class VectorPageRecord
+{
+    [VectorStoreKey]
+    public int PageId { get; set; }
+
+    [VectorStoreData]
+    public string Slug { get; set; } = string.Empty;
+
+    [VectorStoreData]
+    public string Title { get; set; } = string.Empty;
+
+    [VectorStoreData]
+    public string Url { get; set; } = string.Empty;
+
+    [VectorStoreData]
+    public string Excerpt { get; set; } = string.Empty;
+
+    [VectorStoreData]
+    public long UpdatedAtTicks { get; set; }
+
+    [VectorStoreData]
+    public string ContentHash { get; set; } = string.Empty;
+
+    [VectorStoreVector(Dimensions: 768)]
+    public ReadOnlyMemory<float> Embedding { get; set; }
+}

--- a/src/BookStack.Mcp.Server/BookStack.Mcp.Server.csproj
+++ b/src/BookStack.Mcp.Server/BookStack.Mcp.Server.csproj
@@ -10,13 +10,18 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.9.0-beta.1" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.7.0-preview.1.25356.2" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.5.0" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\BookStack.Mcp.Server.Data.Abstractions\BookStack.Mcp.Server.Data.Abstractions.csproj" />
+    <ProjectReference Include="..\BookStack.Mcp.Server.Data.Sqlite\BookStack.Mcp.Server.Data.Sqlite.csproj" />
+    <ProjectReference Include="..\BookStack.Mcp.Server.Data.Postgres\BookStack.Mcp.Server.Data.Postgres.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/BookStack.Mcp.Server/BookStack.Mcp.Server.csproj
+++ b/src/BookStack.Mcp.Server/BookStack.Mcp.Server.csproj
@@ -14,4 +14,8 @@
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\BookStack.Mcp.Server.Data.Abstractions\BookStack.Mcp.Server.Data.Abstractions.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/BookStack.Mcp.Server/BookStack.Mcp.Server.csproj
+++ b/src/BookStack.Mcp.Server/BookStack.Mcp.Server.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.0" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
   </ItemGroup>

--- a/src/BookStack.Mcp.Server/Program.cs
+++ b/src/BookStack.Mcp.Server/Program.cs
@@ -27,6 +27,7 @@ if (transport == "stdio")
 
     builder.Configuration.AddInMemoryCollection(MapBookStackEnvVars());
     builder.Services.AddBookStackApiClient(builder.Configuration);
+    builder.Services.AddVectorSearch(builder.Configuration);
     builder.Services
         .AddMcpServer()
         .WithStdioServerTransport()
@@ -50,6 +51,7 @@ else
 
     builder.Configuration.AddInMemoryCollection(MapBookStackEnvVars());
     builder.Services.AddBookStackApiClient(builder.Configuration);
+    builder.Services.AddVectorSearch(builder.Configuration);
 
     var mcpBuilder = builder.Services
         .AddMcpServer()

--- a/src/BookStack.Mcp.Server/api/BookStackApiClient.Pages.cs
+++ b/src/BookStack.Mcp.Server/api/BookStackApiClient.Pages.cs
@@ -12,6 +12,16 @@ public sealed partial class BookStackApiClient
         return SendAsync<ListResponse<Page>>(JsonRequest(HttpMethod.Get, url), cancellationToken);
     }
 
+    public Task<ListResponse<Page>> GetPagesUpdatedSinceAsync(
+        DateTimeOffset updatedAfter,
+        int count = 500,
+        CancellationToken cancellationToken = default)
+    {
+        var timestamp = Uri.EscapeDataString(updatedAfter.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss"));
+        var url = $"pages?count={count}&filter[updated_after]={timestamp}";
+        return SendAsync<ListResponse<Page>>(JsonRequest(HttpMethod.Get, url), cancellationToken);
+    }
+
     public Task<Page> CreatePageAsync(
         CreatePageRequest request,
         CancellationToken cancellationToken = default)

--- a/src/BookStack.Mcp.Server/api/IBookStackApiClient.cs
+++ b/src/BookStack.Mcp.Server/api/IBookStackApiClient.cs
@@ -22,6 +22,7 @@ public interface IBookStackApiClient
 
     // Pages
     Task<ListResponse<Page>> ListPagesAsync(ListQueryParams? query = null, CancellationToken cancellationToken = default);
+    Task<ListResponse<Page>> GetPagesUpdatedSinceAsync(DateTimeOffset updatedAfter, int count = 500, CancellationToken cancellationToken = default);
     Task<Page> CreatePageAsync(CreatePageRequest request, CancellationToken cancellationToken = default);
     Task<PageWithContent> GetPageAsync(int id, CancellationToken cancellationToken = default);
     Task<Page> UpdatePageAsync(int id, UpdatePageRequest request, CancellationToken cancellationToken = default);

--- a/src/BookStack.Mcp.Server/api/VectorSearchServiceCollectionExtensions.cs
+++ b/src/BookStack.Mcp.Server/api/VectorSearchServiceCollectionExtensions.cs
@@ -1,0 +1,133 @@
+using Azure;
+using Azure.AI.OpenAI;
+using BookStack.Mcp.Server.Config;
+using BookStack.Mcp.Server.Data.Abstractions;
+using BookStack.Mcp.Server.Data.Postgres;
+using BookStack.Mcp.Server.Data.Sqlite;
+using BookStack.Mcp.Server.Services;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace BookStack.Mcp.Server.Api;
+
+public static class VectorSearchServiceCollectionExtensions
+{
+    public static IServiceCollection AddVectorSearch(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<VectorSearchOptions>(
+            configuration.GetSection("VectorSearch"));
+
+        var options = configuration
+            .GetSection("VectorSearch")
+            .Get<VectorSearchOptions>() ?? new VectorSearchOptions();
+
+        if (!options.Enabled)
+        {
+            // Register no-op implementations so that SemanticSearchToolHandler
+            // can still be resolved by the MCP assembly scan. The handler checks
+            // options.Enabled before calling either dependency.
+            services.AddSingleton<IVectorStore, DisabledVectorStore>();
+            services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>, DisabledEmbeddingGenerator>();
+            return services;
+        }
+
+        RegisterEmbeddingGenerator(services, options);
+        RegisterVectorStore(services, options, configuration);
+
+        services.AddHostedService<VectorIndexSyncService>();
+
+        return services;
+    }
+
+    private static void RegisterEmbeddingGenerator(
+        IServiceCollection services,
+        VectorSearchOptions options)
+    {
+        var provider = options.EmbeddingProvider;
+
+        if (string.Equals(provider, "AzureOpenAI", StringComparison.OrdinalIgnoreCase))
+        {
+            services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(sp =>
+            {
+                var opts = sp.GetRequiredService<IOptions<VectorSearchOptions>>().Value.AzureOpenAI;
+                var client = new AzureOpenAIClient(
+                    new Uri(opts.Endpoint),
+                    new AzureKeyCredential(opts.ApiKey));
+                return client.GetEmbeddingClient(opts.DeploymentName).AsIEmbeddingGenerator();
+            });
+        }
+        else
+        {
+            // Default: Ollama
+            services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(sp =>
+            {
+                var opts = sp.GetRequiredService<IOptions<VectorSearchOptions>>().Value.Ollama;
+                return new OllamaEmbeddingGenerator(opts.BaseUrl, opts.Model);
+            });
+        }
+    }
+
+    private static void RegisterVectorStore(
+        IServiceCollection services,
+        VectorSearchOptions options,
+        IConfiguration configuration)
+    {
+        var db = options.Database;
+        var connectionString = configuration.GetConnectionString("VectorDb")
+            ?? "Data Source=bookstack-vectors.db";
+
+        if (string.Equals(db, "Postgres", StringComparison.OrdinalIgnoreCase))
+        {
+            services.AddPostgresVectorStore(connectionString);
+        }
+        else
+        {
+            // Default: Sqlite
+            services.AddSqliteVectorStore(connectionString);
+        }
+    }
+
+    private sealed class DisabledVectorStore : IVectorStore
+    {
+        public Task UpsertAsync(VectorPageEntry entry, ReadOnlyMemory<float> vector, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Vector search is disabled.");
+
+        public Task<IReadOnlyList<VectorSearchResult>> SearchAsync(ReadOnlyMemory<float> queryVector, int topN, float minScore, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Vector search is disabled.");
+
+        public Task DeleteAsync(int pageId, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Vector search is disabled.");
+
+        public Task<string?> GetContentHashAsync(int pageId, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Vector search is disabled.");
+
+        public Task<DateTimeOffset?> GetLastSyncAtAsync(CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Vector search is disabled.");
+
+        public Task SetLastSyncAtAsync(DateTimeOffset timestamp, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Vector search is disabled.");
+    }
+
+    private sealed class DisabledEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        public EmbeddingGeneratorMetadata Metadata { get; } = new("disabled", null, null, null);
+
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
+            IEnumerable<string> values,
+            EmbeddingGenerationOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Vector search is disabled.");
+
+        public TService? GetService<TService>(object? key = null) where TService : class
+            => null;
+
+        object? IEmbeddingGenerator.GetService(Type serviceType, object? key)
+            => null;
+
+        public void Dispose() { }
+    }
+}

--- a/src/BookStack.Mcp.Server/appsettings.json
+++ b/src/BookStack.Mcp.Server/appsettings.json
@@ -6,5 +6,26 @@
       "Microsoft.Hosting.Lifetime": "Information",
       "BookStack.Mcp.Server": "Information"
     }
+  },
+  "ConnectionStrings": {
+    "VectorDb": "Data Source=bookstack-vectors.db"
+  },
+  "VectorSearch": {
+    "Enabled": false,
+    "EmbeddingProvider": "Ollama",
+    "Database": "Sqlite",
+    "Ollama": {
+      "BaseUrl": "http://localhost:11434",
+      "Model": "nomic-embed-text"
+    },
+    "AzureOpenAI": {
+      "Endpoint": "",
+      "DeploymentName": "",
+      "ApiKey": ""
+    },
+    "Sync": {
+      "IntervalHours": 24.0,
+      "BatchSize": 50
+    }
   }
 }

--- a/src/BookStack.Mcp.Server/config/VectorSearchOptions.cs
+++ b/src/BookStack.Mcp.Server/config/VectorSearchOptions.cs
@@ -1,0 +1,46 @@
+namespace BookStack.Mcp.Server.Config;
+
+public sealed class VectorSearchOptions
+{
+    public bool Enabled { get; set; } = false;
+
+    /// <summary>"Postgres" | "SqlServer" | "Sqlite"</summary>
+    public string Database { get; set; } = VectorSearchDefaults.Database;
+
+    /// <summary>"Ollama" | "AzureOpenAI"</summary>
+    public string EmbeddingProvider { get; set; } = VectorSearchDefaults.EmbeddingProvider;
+
+    public OllamaEmbeddingOptions Ollama { get; set; } = new();
+    public AzureOpenAIEmbeddingOptions AzureOpenAI { get; set; } = new();
+    public VectorSyncOptions Sync { get; set; } = new();
+}
+
+public sealed class OllamaEmbeddingOptions
+{
+    public string BaseUrl { get; set; } = VectorSearchDefaults.OllamaBaseUrl;
+    public string Model { get; set; } = VectorSearchDefaults.OllamaModel;
+}
+
+public sealed class AzureOpenAIEmbeddingOptions
+{
+    public string Endpoint { get; set; } = string.Empty;
+    public string DeploymentName { get; set; } = string.Empty;
+    public string ApiKey { get; set; } = string.Empty;
+}
+
+public sealed class VectorSyncOptions
+{
+    public double IntervalHours { get; set; } = VectorSearchDefaults.SyncIntervalHours;
+    public int BatchSize { get; set; } = VectorSearchDefaults.SyncBatchSize;
+}
+
+public static class VectorSearchDefaults
+{
+    public const string Database = "Sqlite";
+    public const string EmbeddingProvider = "Ollama";
+    public const string OllamaBaseUrl = "http://localhost:11434";
+    public const string OllamaModel = "nomic-embed-text";
+    public const double SyncIntervalHours = 24.0;
+    public const int SyncBatchSize = 50;
+    public const int EmbeddingDimensions = 768;
+}

--- a/src/BookStack.Mcp.Server/services/VectorIndexSyncService.cs
+++ b/src/BookStack.Mcp.Server/services/VectorIndexSyncService.cs
@@ -1,0 +1,181 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Config;
+using BookStack.Mcp.Server.Data.Abstractions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BookStack.Mcp.Server.Services;
+
+internal sealed partial class VectorIndexSyncService(
+    IVectorStore vectorStore,
+    IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
+    IBookStackApiClient apiClient,
+    IOptions<VectorSearchOptions> options,
+    IOptions<BookStackApiClientOptions> clientOptions,
+    ILogger<VectorIndexSyncService> logger)
+    : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation(
+            "VectorIndexSyncService started. Sync interval: {Hours}h",
+            options.Value.Sync.IntervalHours);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await RunSyncCycleAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Vector index sync cycle failed unexpectedly.");
+            }
+
+            try
+            {
+                await Task.Delay(
+                    TimeSpan.FromHours(options.Value.Sync.IntervalHours),
+                    stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        logger.LogInformation("VectorIndexSyncService stopped.");
+    }
+
+    private async Task RunSyncCycleAsync(CancellationToken ct)
+    {
+        var lastSyncAt = await vectorStore.GetLastSyncAtAsync(ct).ConfigureAwait(false)
+            ?? DateTimeOffset.MinValue;
+
+        logger.LogInformation("Starting vector index sync. Last sync: {LastSync}", lastSyncAt);
+
+        var response = await apiClient
+            .GetPagesUpdatedSinceAsync(lastSyncAt, cancellationToken: ct)
+            .ConfigureAwait(false);
+
+        logger.LogInformation("Found {Count} pages to process.", response.Data.Count);
+
+        var bookSlugCache = new Dictionary<int, string>();
+        var synced = 0;
+        var skipped = 0;
+
+        foreach (var page in response.Data)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            try
+            {
+                var wasUpserted = await SyncPageAsync(page, bookSlugCache, ct).ConfigureAwait(false);
+                if (wasUpserted)
+                {
+                    synced++;
+                }
+                else
+                {
+                    skipped++;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Failed to sync page {PageId} ({Title}); skipping.",
+                    page.Id,
+                    page.Name);
+                skipped++;
+            }
+        }
+
+        await vectorStore.SetLastSyncAtAsync(DateTimeOffset.UtcNow, ct).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "Vector index sync complete. Upserted: {Synced}, Skipped: {Skipped}.",
+            synced,
+            skipped);
+    }
+
+    private async Task<bool> SyncPageAsync(
+        Page page,
+        Dictionary<int, string> bookSlugCache,
+        CancellationToken ct)
+    {
+        var fullPage = await apiClient.GetPageAsync(page.Id, ct).ConfigureAwait(false);
+        var contentHash = ComputeSha256(fullPage.Html);
+
+        var storedHash = await vectorStore.GetContentHashAsync(page.Id, ct).ConfigureAwait(false);
+        if (contentHash == storedHash)
+        {
+            logger.LogDebug("Page {PageId} content unchanged; skipping.", page.Id);
+            return false;
+        }
+
+        var embeddings = await embeddingGenerator
+            .GenerateAsync([fullPage.Html], cancellationToken: ct)
+            .ConfigureAwait(false);
+        var vector = embeddings[0].Vector;
+
+        if (!bookSlugCache.TryGetValue(page.BookId, out var bookSlug))
+        {
+            var book = await apiClient.GetBookAsync(page.BookId, ct).ConfigureAwait(false);
+            bookSlug = book.Slug;
+            bookSlugCache[page.BookId] = bookSlug;
+        }
+
+        var baseUrl = clientOptions.Value.BaseUrl.TrimEnd('/');
+        var entry = new VectorPageEntry
+        {
+            PageId = page.Id,
+            Slug = page.Slug,
+            Title = page.Name,
+            Url = $"{baseUrl}/books/{bookSlug}/pages/{page.Slug}",
+            Excerpt = ExtractExcerpt(fullPage.Html),
+            UpdatedAt = page.UpdatedAt,
+            ContentHash = contentHash,
+        };
+
+        await vectorStore.UpsertAsync(entry, vector, ct).ConfigureAwait(false);
+
+        logger.LogDebug("Upserted vector for page {PageId} ({Title}).", page.Id, page.Name);
+
+        return true;
+    }
+
+    private static string ComputeSha256(string content)
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash);
+    }
+
+    private static string ExtractExcerpt(string htmlContent)
+    {
+        var plain = StripTagsRegex().Replace(htmlContent, " ");
+        plain = WhitespaceRegex().Replace(plain, " ").Trim();
+        return plain.Length <= 300 ? plain : plain[..300];
+    }
+
+    [GeneratedRegex("<[^>]+>")]
+    private static partial Regex StripTagsRegex();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
+}

--- a/src/BookStack.Mcp.Server/tools/semantic-search/SemanticSearchToolHandler.cs
+++ b/src/BookStack.Mcp.Server/tools/semantic-search/SemanticSearchToolHandler.cs
@@ -1,0 +1,96 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BookStack.Mcp.Server.Config;
+using BookStack.Mcp.Server.Data.Abstractions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Server;
+
+namespace BookStack.Mcp.Server.Tools.SemanticSearch;
+
+[McpServerToolType]
+internal sealed class SemanticSearchToolHandler(
+    IVectorStore vectorStore,
+    IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
+    IOptions<VectorSearchOptions> options,
+    ILogger<SemanticSearchToolHandler> logger)
+{
+    private readonly IVectorStore _vectorStore = vectorStore;
+    private readonly IEmbeddingGenerator<string, Embedding<float>> _embeddingGenerator = embeddingGenerator;
+    private readonly IOptions<VectorSearchOptions> _options = options;
+    private readonly ILogger<SemanticSearchToolHandler> _logger = logger;
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
+
+    [McpServerTool(Name = "bookstack_semantic_search")]
+    [Description("Search BookStack pages by semantic meaning using vector similarity. Returns pages ranked by relevance to the natural-language query. The vector index must be populated by enabling VectorSearch and allowing the background sync to run.")]
+    public async Task<string> SemanticSearchAsync(
+        [Description("Natural-language query describing the content to find. Required.")] string query,
+        [Description("Maximum number of results to return. Range 1–50. Defaults to 5.")] int topN = 5,
+        [Description("Minimum similarity score threshold (0.0–1.0). Results below this score are excluded. Defaults to 0.7.")] float minScore = 0.7f,
+        CancellationToken ct = default)
+    {
+        if (!_options.Value.Enabled)
+        {
+            return "Vector search is disabled. Set VectorSearch:Enabled to true to use this tool.";
+        }
+
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return JsonSerializer.Serialize(
+                new { error = "validation_error", message = "query is required and cannot be empty." },
+                _jsonOptions);
+        }
+
+        if (topN < 1 || topN > 50)
+        {
+            return JsonSerializer.Serialize(
+                new { error = "validation_error", message = "top_n must be between 1 and 50." },
+                _jsonOptions);
+        }
+
+        try
+        {
+            var embeddings = await _embeddingGenerator
+                .GenerateAsync([query], cancellationToken: ct)
+                .ConfigureAwait(false);
+
+            var queryVector = embeddings[0].Vector;
+
+            var results = await _vectorStore
+                .SearchAsync(queryVector, topN, minScore, ct)
+                .ConfigureAwait(false);
+
+            if (results.Count == 0)
+            {
+                return "[]";
+            }
+
+            var output = results
+                .OrderByDescending(r => r.Score)
+                .Select(r => new SemanticSearchResultDto(r.PageId, r.Title, r.Url, r.Excerpt, r.Score));
+
+            return JsonSerializer.Serialize(output, _jsonOptions);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Semantic search failed for query.");
+            return JsonSerializer.Serialize(
+                new { error = "search_error", message = "An error occurred while performing semantic search." },
+                _jsonOptions);
+        }
+    }
+
+    private sealed record SemanticSearchResultDto(
+        [property: JsonPropertyName("pageId")] int PageId,
+        [property: JsonPropertyName("title")] string Title,
+        [property: JsonPropertyName("url")] string Url,
+        [property: JsonPropertyName("excerpt")] string Excerpt,
+        [property: JsonPropertyName("score")] float Score);
+}

--- a/tests/BookStack.Mcp.Server.Tests/BookStack.Mcp.Server.Tests.csproj
+++ b/tests/BookStack.Mcp.Server.Tests/BookStack.Mcp.Server.Tests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\BookStack.Mcp.Server\BookStack.Mcp.Server.csproj" />
+    <ProjectReference Include="..\..\src\BookStack.Mcp.Server.Data.Abstractions\BookStack.Mcp.Server.Data.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/BookStack.Mcp.Server.Tests/Fakes/InMemoryVectorStore.cs
+++ b/tests/BookStack.Mcp.Server.Tests/Fakes/InMemoryVectorStore.cs
@@ -1,0 +1,85 @@
+using BookStack.Mcp.Server.Data.Abstractions;
+
+namespace BookStack.Mcp.Server.Tests.Fakes;
+
+/// <summary>
+/// In-process IVectorStore implementation for unit tests.
+/// No database required; cosine similarity computed in C#.
+/// </summary>
+public sealed class InMemoryVectorStore : IVectorStore
+{
+    private readonly List<(VectorPageEntry Entry, float[] Vector)> _records = [];
+    private DateTimeOffset? _lastSyncAt;
+
+    public Task UpsertAsync(VectorPageEntry entry, ReadOnlyMemory<float> vector, CancellationToken cancellationToken = default)
+    {
+        _records.RemoveAll(r => r.Entry.PageId == entry.PageId);
+        _records.Add((entry, vector.ToArray()));
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<VectorSearchResult>> SearchAsync(
+        ReadOnlyMemory<float> queryVector,
+        int topN,
+        float minScore,
+        CancellationToken cancellationToken = default)
+    {
+        var query = queryVector.ToArray();
+
+        var results = _records
+            .Select(r => new VectorSearchResult
+            {
+                PageId = r.Entry.PageId,
+                Title = r.Entry.Title,
+                Url = r.Entry.Url,
+                Excerpt = r.Entry.Excerpt,
+                Score = CosineSimilarity(query, r.Vector),
+            })
+            .Where(r => r.Score >= minScore)
+            .OrderByDescending(r => r.Score)
+            .Take(topN)
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<VectorSearchResult>>(results);
+    }
+
+    public Task DeleteAsync(int pageId, CancellationToken cancellationToken = default)
+    {
+        _records.RemoveAll(r => r.Entry.PageId == pageId);
+        return Task.CompletedTask;
+    }
+
+    public Task<string?> GetContentHashAsync(int pageId, CancellationToken cancellationToken = default)
+    {
+        var entry = _records.FirstOrDefault(r => r.Entry.PageId == pageId).Entry;
+        return Task.FromResult<string?>(entry?.ContentHash);
+    }
+
+    public Task<DateTimeOffset?> GetLastSyncAtAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(_lastSyncAt);
+
+    public Task SetLastSyncAtAsync(DateTimeOffset timestamp, CancellationToken cancellationToken = default)
+    {
+        _lastSyncAt = timestamp;
+        return Task.CompletedTask;
+    }
+
+    private static float CosineSimilarity(float[] a, float[] b)
+    {
+        if (a.Length != b.Length || a.Length == 0)
+        {
+            return 0f;
+        }
+
+        float dot = 0f, magA = 0f, magB = 0f;
+        for (var i = 0; i < a.Length; i++)
+        {
+            dot += a[i] * b[i];
+            magA += a[i] * a[i];
+            magB += b[i] * b[i];
+        }
+
+        var denom = MathF.Sqrt(magA) * MathF.Sqrt(magB);
+        return denom == 0f ? 0f : dot / denom;
+    }
+}

--- a/tests/BookStack.Mcp.Server.Tests/VectorSearch/SemanticSearchToolHandlerTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/VectorSearch/SemanticSearchToolHandlerTests.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using BookStack.Mcp.Server.Config;
+using BookStack.Mcp.Server.Data.Abstractions;
+using BookStack.Mcp.Server.Tools.SemanticSearch;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace BookStack.Mcp.Server.Tests.VectorSearch;
+
+public sealed class SemanticSearchToolHandlerTests
+{
+    private readonly Mock<IVectorStore> _mockStore = new();
+    private readonly Mock<IEmbeddingGenerator<string, Embedding<float>>> _mockEmbGen = new();
+
+    private static readonly VectorSearchOptions _enabledOptions = new() { Enabled = true };
+
+    private SemanticSearchToolHandler CreateHandler(VectorSearchOptions? options = null)
+        => new(
+            _mockStore.Object,
+            _mockEmbGen.Object,
+            Options.Create(options ?? _enabledOptions),
+            NullLogger<SemanticSearchToolHandler>.Instance);
+
+    private static GeneratedEmbeddings<Embedding<float>> MakeEmbeddings(float[] vector)
+        => new GeneratedEmbeddings<Embedding<float>>([new Embedding<float>(vector)]);
+
+    private void SetupEmbedding(float[] vector)
+    {
+        _mockEmbGen
+            .Setup(g => g.GenerateAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<EmbeddingGenerationOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeEmbeddings(vector));
+    }
+
+    // T25 — empty query returns validation error, no embedding call
+    [Test]
+    public async Task SemanticSearchAsync_EmptyQuery_ReturnsValidationError()
+    {
+        var handler = CreateHandler();
+
+        var result = await handler.SemanticSearchAsync("   ").ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("error").GetString().Should().Be("validation_error");
+        _mockEmbGen.Verify(
+            g => g.GenerateAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<EmbeddingGenerationOptions?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // T26a — topN = 0 returns validation error
+    [Test]
+    public async Task SemanticSearchAsync_TopNZero_ReturnsValidationError()
+    {
+        var handler = CreateHandler();
+
+        var result = await handler.SemanticSearchAsync("some query", topN: 0).ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("error").GetString().Should().Be("validation_error");
+    }
+
+    // T26b — topN = 51 returns validation error
+    [Test]
+    public async Task SemanticSearchAsync_TopNFiftyOne_ReturnsValidationError()
+    {
+        var handler = CreateHandler();
+
+        var result = await handler.SemanticSearchAsync("some query", topN: 51).ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("error").GetString().Should().Be("validation_error");
+    }
+
+    // T27 — empty vector index returns "[]"
+    [Test]
+    public async Task SemanticSearchAsync_EmptyIndex_ReturnsEmptyArray()
+    {
+        SetupEmbedding([1f, 0f]);
+        _mockStore
+            .Setup(s => s.SearchAsync(It.IsAny<ReadOnlyMemory<float>>(), It.IsAny<int>(), It.IsAny<float>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<VectorSearchResult>());
+
+        var handler = CreateHandler();
+
+        var result = await handler.SemanticSearchAsync("what is on-call policy?").ConfigureAwait(false);
+
+        result.Should().Be("[]");
+    }
+
+    // T28 — VectorSearch:Enabled=false returns feature-disabled message
+    [Test]
+    public async Task SemanticSearchAsync_FeatureDisabled_ReturnsDisabledMessage()
+    {
+        var handler = CreateHandler(new VectorSearchOptions { Enabled = false });
+
+        var result = await handler.SemanticSearchAsync("any query").ConfigureAwait(false);
+
+        result.Should().Contain("Vector search is disabled");
+        _mockEmbGen.Verify(
+            g => g.GenerateAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<EmbeddingGenerationOptions?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockStore.Verify(
+            s => s.SearchAsync(It.IsAny<ReadOnlyMemory<float>>(), It.IsAny<int>(), It.IsAny<float>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // T29 — populated index returns JSON array sorted by descending score
+    [Test]
+    public async Task SemanticSearchAsync_PopulatedIndex_ReturnsSortedJsonArray()
+    {
+        SetupEmbedding([1f, 0f]);
+        _mockStore
+            .Setup(s => s.SearchAsync(It.IsAny<ReadOnlyMemory<float>>(), It.IsAny<int>(), It.IsAny<float>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<VectorSearchResult>
+            {
+                new() { PageId = 1, Title = "Page A", Url = "http://bs.test/a", Excerpt = "Excerpt A", Score = 0.75f },
+                new() { PageId = 2, Title = "Page B", Url = "http://bs.test/b", Excerpt = "Excerpt B", Score = 0.95f },
+                new() { PageId = 3, Title = "Page C", Url = "http://bs.test/c", Excerpt = "Excerpt C", Score = 0.85f },
+            });
+
+        var handler = CreateHandler();
+
+        var result = await handler.SemanticSearchAsync("test query").ConfigureAwait(false);
+
+        var doc = JsonDocument.Parse(result);
+        var items = doc.RootElement.EnumerateArray().ToList();
+        items.Should().HaveCount(3);
+
+        // Verify descending score order
+        var scores = items.Select(i => i.GetProperty("score").GetSingle()).ToList();
+        scores.Should().BeInDescendingOrder();
+        scores[0].Should().BeApproximately(0.95f, 0.001f);
+        scores[1].Should().BeApproximately(0.85f, 0.001f);
+        scores[2].Should().BeApproximately(0.75f, 0.001f);
+    }
+
+    // T30 — min_score=1.0 with sub-threshold results returns "[]"
+    [Test]
+    public async Task SemanticSearchAsync_MinScoreOneWithSubThresholdResults_ReturnsEmptyArray()
+    {
+        SetupEmbedding([1f, 0f]);
+        _mockStore
+            .Setup(s => s.SearchAsync(It.IsAny<ReadOnlyMemory<float>>(), It.IsAny<int>(), 1.0f, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<VectorSearchResult>());
+
+        var handler = CreateHandler();
+
+        var result = await handler.SemanticSearchAsync("some query", minScore: 1.0f).ConfigureAwait(false);
+
+        result.Should().Be("[]");
+    }
+}

--- a/tests/BookStack.Mcp.Server.Tests/VectorSearch/VectorIndexSyncServiceTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/VectorSearch/VectorIndexSyncServiceTests.cs
@@ -1,0 +1,203 @@
+using System.Security.Cryptography;
+using System.Text;
+using BookStack.Mcp.Server.Api;
+using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Config;
+using BookStack.Mcp.Server.Data.Abstractions;
+using BookStack.Mcp.Server.Services;
+using BookStack.Mcp.Server.Tests.Fakes;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace BookStack.Mcp.Server.Tests.VectorSearch;
+
+public sealed class VectorIndexSyncServiceTests
+{
+    private readonly Mock<IVectorStore> _mockStore = new();
+    private readonly Mock<IEmbeddingGenerator<string, Embedding<float>>> _mockEmbGen = new();
+    private readonly Mock<IBookStackApiClient> _mockClient = new();
+
+    private static readonly IOptions<VectorSearchOptions> _options = Options.Create(new VectorSearchOptions
+    {
+        Enabled = true,
+        Sync = new VectorSyncOptions { IntervalHours = 10_000 }, // prevent immediate re-loop
+    });
+
+    private static readonly IOptions<BookStackApiClientOptions> _clientOptions = Options.Create(new BookStackApiClientOptions
+    {
+        BaseUrl = "http://bookstack.test",
+    });
+
+    private VectorIndexSyncService CreateService() => new(
+        _mockStore.Object,
+        _mockEmbGen.Object,
+        _mockClient.Object,
+        _options,
+        _clientOptions,
+        NullLogger<VectorIndexSyncService>.Instance);
+
+    private static string ComputeHash(string content)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(content)));
+
+    private static GeneratedEmbeddings<Embedding<float>> MakeEmbeddings(float[] vector)
+        => new GeneratedEmbeddings<Embedding<float>>([new Embedding<float>(vector)]);
+
+    private TaskCompletionSource WireSetLastSyncAt()
+    {
+        var cycleDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _mockStore.Setup(s => s.SetLastSyncAtAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .Callback<DateTimeOffset, CancellationToken>((_, _) => cycleDone.TrySetResult())
+            .Returns(Task.CompletedTask);
+        return cycleDone;
+    }
+
+    // T21 — unchanged content hash: skips embedding generator
+    [Test]
+    public async Task SyncCycle_UnchangedContentHash_DoesNotCallEmbeddingGenerator()
+    {
+        const string html = "<p>Existing content</p>";
+        var hash = ComputeHash(html);
+
+        _mockStore.Setup(s => s.GetLastSyncAtAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTimeOffset?)null);
+        _mockClient
+            .Setup(c => c.GetPagesUpdatedSinceAsync(It.IsAny<DateTimeOffset>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListResponse<Page> { Data = [new Page { Id = 1, BookId = 1 }], Total = 1 });
+        _mockClient.Setup(c => c.GetPageAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PageWithContent { Id = 1, Html = html });
+        _mockStore.Setup(s => s.GetContentHashAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(hash); // already up to date
+
+        var cycleDone = WireSetLastSyncAt();
+
+        using var service = CreateService();
+        await service.StartAsync(CancellationToken.None).ConfigureAwait(false);
+        await cycleDone.Task.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+        await service.StopAsync(CancellationToken.None).ConfigureAwait(false);
+
+        _mockEmbGen.Verify(
+            g => g.GenerateAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<EmbeddingGenerationOptions?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // T22 — new page: UpsertAsync called with correct metadata
+    [Test]
+    public async Task SyncCycle_NewPage_CallsUpsertWithCorrectMetadata()
+    {
+        const string html = "<p>New page content</p>";
+        var updatedAt = new DateTimeOffset(2025, 1, 15, 10, 0, 0, TimeSpan.Zero);
+
+        _mockStore.Setup(s => s.GetLastSyncAtAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTimeOffset?)null);
+        _mockClient
+            .Setup(c => c.GetPagesUpdatedSinceAsync(It.IsAny<DateTimeOffset>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListResponse<Page>
+            {
+                Data = [new Page { Id = 7, BookId = 3, Name = "Test Page", Slug = "test-page", UpdatedAt = updatedAt }],
+                Total = 1,
+            });
+        _mockClient.Setup(c => c.GetPageAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PageWithContent { Id = 7, Html = html });
+        _mockStore.Setup(s => s.GetContentHashAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        _mockEmbGen
+            .Setup(g => g.GenerateAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<EmbeddingGenerationOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeEmbeddings([0.5f, 0.5f]));
+        _mockClient.Setup(c => c.GetBookAsync(3, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BookWithContents { Id = 3, Slug = "test-book" });
+        _mockStore.Setup(s => s.UpsertAsync(It.IsAny<VectorPageEntry>(), It.IsAny<ReadOnlyMemory<float>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var cycleDone = WireSetLastSyncAt();
+
+        using var service = CreateService();
+        await service.StartAsync(CancellationToken.None).ConfigureAwait(false);
+        await cycleDone.Task.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+        await service.StopAsync(CancellationToken.None).ConfigureAwait(false);
+
+        _mockStore.Verify(
+            s => s.UpsertAsync(
+                It.Is<VectorPageEntry>(e =>
+                    e.PageId == 7 &&
+                    e.Title == "Test Page" &&
+                    e.Slug == "test-page" &&
+                    e.Url == "http://bookstack.test/books/test-book/pages/test-page" &&
+                    e.UpdatedAt == updatedAt),
+                It.IsAny<ReadOnlyMemory<float>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // T23 — per-page embedding failure: cycle continues for remaining pages
+    [Test]
+    public async Task SyncCycle_EmbeddingFailsForOnePage_ContinuesAndSyncsOtherPages()
+    {
+        _mockStore.Setup(s => s.GetLastSyncAtAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTimeOffset?)null);
+        _mockClient
+            .Setup(c => c.GetPagesUpdatedSinceAsync(It.IsAny<DateTimeOffset>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListResponse<Page>
+            {
+                Data =
+                [
+                    new Page { Id = 1, BookId = 1, Name = "Page One", Slug = "page-one" },
+                    new Page { Id = 2, BookId = 1, Name = "Page Two", Slug = "page-two" },
+                ],
+                Total = 2,
+            });
+        _mockClient.Setup(c => c.GetPageAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((int id, CancellationToken _) => new PageWithContent { Id = id, Html = $"<p>Content {id}</p>" });
+        _mockStore.Setup(s => s.GetContentHashAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        _mockEmbGen
+            .SetupSequence(g => g.GenerateAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<EmbeddingGenerationOptions?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Embedding service unavailable"))
+            .ReturnsAsync(MakeEmbeddings([0.5f, 0.5f]));
+
+        _mockClient.Setup(c => c.GetBookAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BookWithContents { Id = 1, Slug = "test-book" });
+        _mockStore.Setup(s => s.UpsertAsync(It.IsAny<VectorPageEntry>(), It.IsAny<ReadOnlyMemory<float>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var cycleDone = WireSetLastSyncAt();
+
+        using var service = CreateService();
+        await service.StartAsync(CancellationToken.None).ConfigureAwait(false);
+        await cycleDone.Task.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+        await service.StopAsync(CancellationToken.None).ConfigureAwait(false);
+
+        // Only page 2 should have been upserted (page 1 embedding failed)
+        _mockStore.Verify(
+            s => s.UpsertAsync(It.Is<VectorPageEntry>(e => e.PageId == 2), It.IsAny<ReadOnlyMemory<float>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockStore.Verify(
+            s => s.UpsertAsync(It.Is<VectorPageEntry>(e => e.PageId == 1), It.IsAny<ReadOnlyMemory<float>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // T24 — SetLastSyncAtAsync called exactly once per successful cycle
+    [Test]
+    public async Task SyncCycle_Success_CallsSetLastSyncAtOnce()
+    {
+        _mockStore.Setup(s => s.GetLastSyncAtAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTimeOffset?)null);
+        _mockClient
+            .Setup(c => c.GetPagesUpdatedSinceAsync(It.IsAny<DateTimeOffset>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListResponse<Page> { Data = [], Total = 0 });
+
+        var cycleDone = WireSetLastSyncAt();
+
+        using var service = CreateService();
+        await service.StartAsync(CancellationToken.None).ConfigureAwait(false);
+        await cycleDone.Task.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+        await service.StopAsync(CancellationToken.None).ConfigureAwait(false);
+
+        _mockStore.Verify(
+            s => s.SetLastSyncAtAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/tests/BookStack.Mcp.Server.Tests/VectorSearch/VectorSearchIntegrationTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/VectorSearch/VectorSearchIntegrationTests.cs
@@ -1,0 +1,99 @@
+using BookStack.Mcp.Server.Api.Models;
+using BookStack.Mcp.Server.Config;
+using BookStack.Mcp.Server.Data.Abstractions;
+using BookStack.Mcp.Server.Tests.Fakes;
+using BookStack.Mcp.Server.Tests.Helpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace BookStack.Mcp.Server.Tests.VectorSearch;
+
+public sealed class VectorSearchIntegrationTests
+{
+    // T31 — UpsertAsync then SearchAsync returns expected result
+    [Test]
+    public async Task InMemoryVectorStore_UpsertThenSearch_ReturnsMatchingEntry()
+    {
+        var store = new InMemoryVectorStore();
+        var entry = new VectorPageEntry
+        {
+            PageId = 42,
+            Title = "Reset Password",
+            Url = "http://bs.test/books/help/pages/reset-password",
+            Excerpt = "How to reset your password.",
+            Slug = "reset-password",
+            UpdatedAt = DateTimeOffset.UtcNow,
+            ContentHash = "abc123",
+        };
+
+        // Unit vector along first dimension — cosine similarity with identical query = 1.0
+        var vector = new float[] { 1f, 0f, 0f };
+        await store.UpsertAsync(entry, vector).ConfigureAwait(false);
+
+        var results = await store.SearchAsync(
+            queryVector: new float[] { 1f, 0f, 0f },
+            topN: 5,
+            minScore: 0.9f).ConfigureAwait(false);
+
+        results.Should().HaveCount(1);
+        results[0].PageId.Should().Be(42);
+        results[0].Title.Should().Be("Reset Password");
+        results[0].Score.Should().BeApproximately(1.0f, 0.001f);
+    }
+
+    // T32 — GetContentHashAsync returns null before upsert, stored hash after
+    [Test]
+    public async Task InMemoryVectorStore_GetContentHashAsync_ReturnsNullBeforeUpsert_HashAfter()
+    {
+        var store = new InMemoryVectorStore();
+
+        var hashBefore = await store.GetContentHashAsync(99).ConfigureAwait(false);
+        hashBefore.Should().BeNull();
+
+        var entry = new VectorPageEntry
+        {
+            PageId = 99,
+            ContentHash = "deadbeef",
+            Title = "Page",
+            Slug = "page",
+            Url = "http://bs.test/page",
+            Excerpt = string.Empty,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+        await store.UpsertAsync(entry, new float[] { 0.5f }).ConfigureAwait(false);
+
+        var hashAfter = await store.GetContentHashAsync(99).ConfigureAwait(false);
+        hashAfter.Should().Be("deadbeef");
+    }
+
+    // T33 — GetPagesUpdatedSinceAsync sends correct filter query parameter
+    [Test]
+    public async Task BookStackApiClient_GetPagesUpdatedSinceAsync_SendsCorrectFilterParameter()
+    {
+        var json = """{"data":[],"total":0}""";
+        var handler = MockHttpMessageHandler.ReturningJson(json);
+
+        var options = Options.Create(new BookStackApiClientOptions
+        {
+            BaseUrl = "http://bookstack.test",
+            TokenId = "tid",
+            TokenSecret = "tsecret",
+            TimeoutSeconds = 30,
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://bookstack.test/api/"),
+        };
+        var client = new BookStack.Mcp.Server.Api.BookStackApiClient(
+            httpClient, options, NullLogger<BookStack.Mcp.Server.Api.BookStackApiClient>.Instance);
+
+        var since = new DateTimeOffset(2025, 6, 1, 12, 0, 0, TimeSpan.Zero);
+        await client.GetPagesUpdatedSinceAsync(since).ConfigureAwait(false);
+
+        var requestUri = handler.LastRequest!.RequestUri!.AbsoluteUri;
+        requestUri.Should().Contain("pages");
+        requestUri.Should().Contain("filter");
+        requestUri.Should().Contain("2025-06-01");
+    }
+}


### PR DESCRIPTION
## Summary

Implements FEAT-0005 end-to-end — a background vector indexing pipeline and a `bookstack_semantic_search` MCP tool.

Closes #5
Closes #11
Closes #81
Closes #82
Closes #83
Closes #84
Closes #85
Closes #86
Closes #87
Closes #88
Closes #89
Closes #90
Part of #3

## Changes

### Data layer
- `IVectorStore` abstraction with `UpsertAsync`, `SearchAsync`, `DeleteAsync`, `GetContentHashAsync`, `GetLastSyncAtAsync`, `SetLastSyncAtAsync`
- `VectorPageEntry` and `VectorSearchResult` value objects in `Data.Abstractions`
- `SqliteVectorStore` using `Microsoft.SemanticKernel.Connectors.SqliteVec` (SQLite-vec)
- `PgVectorStore` using `Npgsql.EntityFrameworkCore.PostgreSQL` and `pgvector` (cosine similarity)
- `InMemoryVectorStore` test fake with cosine similarity for unit tests

### API client
- `GetPagesUpdatedSinceAsync` on `IBookStackApiClient` / `BookStackApiClient` with `filter[updated_after]` query parameter

### Configuration
- `VectorSearchOptions` (provider, database, sync interval, Ollama / AzureOpenAI settings)
- `appsettings.json` updated with `ConnectionStrings:VectorDb` and `VectorSearch` section (disabled by default)

### Services
- `VectorIndexSyncService` — `BackgroundService` that polls BookStack, skips unchanged pages via SHA-256 content hash, generates embeddings in batches, and upserts to the vector store
- `SemanticSearchToolHandler` — `bookstack_semantic_search` MCP tool; validates `query` / `topN` / `minScore`, embeds the query, calls `IVectorStore.SearchAsync`, returns camelCase JSON sorted by score descending

### DI wiring
- `AddVectorSearch` extension method; selects Ollama or Azure OpenAI embedding provider; selects SQLite or Postgres vector store; registers `VectorIndexSyncService` as hosted service; no-op stubs when `Enabled: false`
- `Program.cs` updated to call `AddVectorSearch` in both stdio and HTTP paths

### Tests (106 total, 0 failed)
- T21–T24: `VectorIndexSyncService` — hash-skip, metadata upsert, per-page error isolation, sync timestamp
- T25–T30: `SemanticSearchToolHandler` — validation, disabled state, empty result, score-sorted output
- T31–T33: `InMemoryVectorStore` round-trip, hash lifecycle, API filter parameter

## Breaking changes

None. Vector search is disabled by default (`VectorSearch:Enabled: false`).

## Checklist

- [x] `dotnet format --verify-no-changes` passes
- [x] All 106 tests pass
- [x] `appsettings.json` defaults are safe (feature disabled)