### PR TITLE
feat(#109): integrate MarkZither.Rag.Chunking into VectorIndexSyncService

### DIFF
--- a/src/BookStack.Mcp.Server/BookStack.Mcp.Server.csproj
+++ b/src/BookStack.Mcp.Server/BookStack.Mcp.Server.csproj
@@ -26,7 +26,10 @@
     <ProjectReference Include="..\BookStack.Mcp.Server.Data.Abstractions\BookStack.Mcp.Server.Data.Abstractions.csproj" />
     <ProjectReference Include="..\BookStack.Mcp.Server.Data.Sqlite\BookStack.Mcp.Server.Data.Sqlite.csproj" />
     <ProjectReference Include="..\BookStack.Mcp.Server.Data.Postgres\BookStack.Mcp.Server.Data.Postgres.csproj" />
-    <ProjectReference Include="..\MarkZither.Rag.Chunking\MarkZither.Rag.Chunking.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MarkZither.Rag.Chunking" Version="[0.0.1-alpha.1,0.1.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/BookStack.Mcp.Server/api/VectorSearchServiceCollectionExtensions.cs
+++ b/src/BookStack.Mcp.Server/api/VectorSearchServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using BookStack.Mcp.Server.Data.Abstractions;
 using BookStack.Mcp.Server.Data.Postgres;
 using BookStack.Mcp.Server.Data.Sqlite;
 using BookStack.Mcp.Server.Services;
+using MarkZither.Rag.Chunking;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,6 +38,7 @@ public static class VectorSearchServiceCollectionExtensions
 
         RegisterEmbeddingGenerator(services, options);
         RegisterVectorStore(services, options, configuration);
+        services.AddChunking();
 
         services.AddSingleton<VectorIndexSyncService>();
         services.AddHostedService(sp => sp.GetRequiredService<VectorIndexSyncService>());

--- a/src/BookStack.Mcp.Server/services/VectorIndexSyncService.cs
+++ b/src/BookStack.Mcp.Server/services/VectorIndexSyncService.cs
@@ -5,6 +5,7 @@ using BookStack.Mcp.Server.Api;
 using BookStack.Mcp.Server.Api.Models;
 using BookStack.Mcp.Server.Config;
 using BookStack.Mcp.Server.Data.Abstractions;
+using MarkZither.Rag.Chunking;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -15,6 +16,7 @@ namespace BookStack.Mcp.Server.Services;
 internal sealed partial class VectorIndexSyncService(
     IVectorStore vectorStore,
     IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
+    IChunkingService chunkingService,
     IBookStackApiClient apiClient,
     IOptions<VectorSearchOptions> options,
     IOptions<BookStackApiClientOptions> clientOptions,
@@ -164,7 +166,24 @@ internal sealed partial class VectorIndexSyncService(
         CancellationToken ct)
     {
         var fullPage = await apiClient.GetPageAsync(page.Id, ct).ConfigureAwait(false);
-        var contentHash = ComputeSha256(fullPage.Html);
+
+        // Prefer Markdown source when the page was authored in the Markdown editor.
+        var useMarkdown = string.Equals(fullPage.Editor, "markdown", StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrWhiteSpace(fullPage.Markdown);
+        var inputText = useMarkdown ? fullPage.Markdown! : fullPage.Html;
+        var inputFormat = useMarkdown ? "markdown" : "html";
+
+        logger.LogDebug("Page {PageId}: using {Format} as embedding input.", page.Id, inputFormat);
+
+        if (!useMarkdown && DrawIORegex().IsMatch(fullPage.Html))
+        {
+            logger.LogWarning(
+                "Page {PageId} ({Title}) contains DrawIO diagram markup; embeddings may be low quality.",
+                page.Id,
+                page.Name);
+        }
+
+        var contentHash = ComputeSha256(inputText);
 
         var storedHash = await vectorStore.GetContentHashAsync(page.Id, ct).ConfigureAwait(false);
         if (contentHash == storedHash)
@@ -172,11 +191,6 @@ internal sealed partial class VectorIndexSyncService(
             logger.LogDebug("Page {PageId} content unchanged; skipping.", page.Id);
             return false;
         }
-
-        var embeddings = await embeddingGenerator
-            .GenerateAsync([fullPage.Html], cancellationToken: ct)
-            .ConfigureAwait(false);
-        var vector = embeddings[0].Vector;
 
         if (!bookSlugCache.TryGetValue(page.BookId, out var bookSlug))
         {
@@ -186,20 +200,69 @@ internal sealed partial class VectorIndexSyncService(
         }
 
         var baseUrl = clientOptions.Value.BaseUrl.TrimEnd('/');
-        var entry = new VectorPageEntry
+        var chunkOpts = options.Value.Chunking;
+
+        await vectorStore.DeleteChunksAsync(page.Id, ct).ConfigureAwait(false);
+
+        if (chunkOpts.ChunkSize == 0)
         {
-            PageId = page.Id,
-            Slug = page.Slug,
-            Title = page.Name,
-            Url = $"{baseUrl}/books/{bookSlug}/pages/{page.Slug}",
-            Excerpt = ExtractExcerpt(fullPage.Html),
-            UpdatedAt = page.UpdatedAt,
-            ContentHash = contentHash,
-        };
+            // Single-embedding fallback — no chunking.
+            var embeddings = await embeddingGenerator
+                .GenerateAsync([inputText], cancellationToken: ct)
+                .ConfigureAwait(false);
 
-        await vectorStore.UpsertAsync(entry, vector, ct).ConfigureAwait(false);
+            var entry = new VectorPageEntry
+            {
+                PageId = page.Id,
+                ChunkIndex = 0,
+                TotalChunks = 1,
+                Slug = page.Slug,
+                Title = page.Name,
+                Url = $"{baseUrl}/books/{bookSlug}/pages/{page.Slug}",
+                Excerpt = ExtractExcerpt(inputText),
+                UpdatedAt = page.UpdatedAt,
+                ContentHash = contentHash,
+            };
 
-        logger.LogDebug("Upserted vector for page {PageId} ({Title}).", page.Id, page.Name);
+            await vectorStore.UpsertAsync(entry, embeddings[0].Vector, ct).ConfigureAwait(false);
+        }
+        else
+        {
+            var chunks = await chunkingService
+                .ChunkAsync(inputText, chunkOpts, ct)
+                .ConfigureAwait(false);
+
+            for (var i = 0; i < chunks.Count; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var chunk = chunks[i];
+                var chunkEmbeddings = await embeddingGenerator
+                    .GenerateAsync([chunk.Text], cancellationToken: ct)
+                    .ConfigureAwait(false);
+
+                var entry = new VectorPageEntry
+                {
+                    PageId = page.Id,
+                    ChunkIndex = chunk.ChunkIndex,
+                    TotalChunks = chunk.TotalChunks,
+                    Slug = page.Slug,
+                    Title = page.Name,
+                    Url = $"{baseUrl}/books/{bookSlug}/pages/{page.Slug}",
+                    Excerpt = ExtractExcerpt(chunk.Text),
+                    UpdatedAt = page.UpdatedAt,
+                    ContentHash = contentHash,
+                };
+
+                await vectorStore.UpsertAsync(entry, chunkEmbeddings[0].Vector, ct).ConfigureAwait(false);
+            }
+        }
+
+        logger.LogDebug(
+            "Upserted vector(s) for page {PageId} ({Title}), format={Format}.",
+            page.Id,
+            page.Name,
+            inputFormat);
 
         return true;
     }
@@ -223,4 +286,7 @@ internal sealed partial class VectorIndexSyncService(
 
     [GeneratedRegex(@"\s+")]
     private static partial Regex WhitespaceRegex();
+
+    [GeneratedRegex(@"<mxGraphModel|data-drawio|class=""drawio""", RegexOptions.IgnoreCase)]
+    private static partial Regex DrawIORegex();
 }

--- a/tests/BookStack.Mcp.Server.Tests/VectorSearch/VectorIndexSyncServiceTests.cs
+++ b/tests/BookStack.Mcp.Server.Tests/VectorSearch/VectorIndexSyncServiceTests.cs
@@ -7,6 +7,7 @@ using BookStack.Mcp.Server.Data.Abstractions;
 using BookStack.Mcp.Server.Services;
 using BookStack.Mcp.Server.Tests.Fakes;
 using FluentAssertions;
+using MarkZither.Rag.Chunking;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -19,11 +20,13 @@ public sealed class VectorIndexSyncServiceTests
     private readonly Mock<IVectorStore> _mockStore = new();
     private readonly Mock<IEmbeddingGenerator<string, Embedding<float>>> _mockEmbGen = new();
     private readonly Mock<IBookStackApiClient> _mockClient = new();
+    private readonly Mock<IChunkingService> _mockChunkingService = new();
 
     private static readonly IOptions<VectorSearchOptions> _options = Options.Create(new VectorSearchOptions
     {
         Enabled = true,
         Sync = new VectorSyncOptions { IntervalHours = 10_000 }, // prevent immediate re-loop
+        Chunking = new ChunkOptions { ChunkSize = 0 }, // single-chunk fallback for existing tests
     });
 
     private static readonly IOptions<BookStackApiClientOptions> _clientOptions = Options.Create(new BookStackApiClientOptions
@@ -34,6 +37,7 @@ public sealed class VectorIndexSyncServiceTests
     private VectorIndexSyncService CreateService() => new(
         _mockStore.Object,
         _mockEmbGen.Object,
+        _mockChunkingService.Object,
         _mockClient.Object,
         _options,
         _clientOptions,
@@ -198,6 +202,189 @@ public sealed class VectorIndexSyncServiceTests
 
         _mockStore.Verify(
             s => s.SetLastSyncAtAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // T25 — Markdown preference: when Editor == "markdown" and Markdown non-empty, hash and embedding use Markdown text
+    [Test]
+    public async Task SyncPageAsync_MarkdownEditor_UsesMarkdownTextForHashAndEmbedding()
+    {
+        const string markdown = "# Hello\n\nMarkdown content.";
+        const string html = "<h1>Hello</h1><p>HTML fallback.</p>";
+
+        _mockStore.Setup(s => s.GetLastSyncAtAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTimeOffset?)null);
+        _mockClient
+            .Setup(c => c.GetPagesUpdatedSinceAsync(It.IsAny<DateTimeOffset>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListResponse<Page>
+            {
+                Data = [new Page { Id = 10, BookId = 1, Name = "MD Page", Slug = "md-page" }],
+                Total = 1,
+            });
+        _mockClient.Setup(c => c.GetPageAsync(10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PageWithContent { Id = 10, Editor = "markdown", Markdown = markdown, Html = html });
+        _mockStore.Setup(s => s.GetContentHashAsync(10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        _mockStore.Setup(s => s.DeleteChunksAsync(10, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _mockEmbGen
+            .Setup(g => g.GenerateAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<EmbeddingGenerationOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeEmbeddings([0.1f]));
+        _mockClient.Setup(c => c.GetBookAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BookWithContents { Id = 1, Slug = "test-book" });
+        _mockStore.Setup(s => s.UpsertAsync(It.IsAny<VectorPageEntry>(), It.IsAny<ReadOnlyMemory<float>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var cycleDone = WireSetLastSyncAt();
+
+        using var service = CreateService();
+        await service.StartAsync(CancellationToken.None).ConfigureAwait(false);
+        await cycleDone.Task.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+        await service.StopAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var expectedHash = ComputeHash(markdown);
+        _mockStore.Verify(
+            s => s.UpsertAsync(
+                It.Is<VectorPageEntry>(e => e.ContentHash == expectedHash && e.PageId == 10),
+                It.IsAny<ReadOnlyMemory<float>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Embedding must be called with the markdown text, not the HTML
+        _mockEmbGen.Verify(
+            g => g.GenerateAsync(
+                It.Is<IEnumerable<string>>(texts => texts.SequenceEqual(new[] { markdown })),
+                It.IsAny<EmbeddingGenerationOptions?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // T26 — HTML fallback: when Editor != "markdown", HTML is used
+    [Test]
+    public async Task SyncPageAsync_NonMarkdownEditor_UsesHtmlTextForHashAndEmbedding()
+    {
+        const string html = "<p>HTML content only.</p>";
+
+        _mockStore.Setup(s => s.GetLastSyncAtAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTimeOffset?)null);
+        _mockClient
+            .Setup(c => c.GetPagesUpdatedSinceAsync(It.IsAny<DateTimeOffset>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListResponse<Page>
+            {
+                Data = [new Page { Id = 11, BookId = 1, Name = "HTML Page", Slug = "html-page" }],
+                Total = 1,
+            });
+        _mockClient.Setup(c => c.GetPageAsync(11, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PageWithContent { Id = 11, Editor = "wysiwyg", Html = html });
+        _mockStore.Setup(s => s.GetContentHashAsync(11, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        _mockStore.Setup(s => s.DeleteChunksAsync(11, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _mockEmbGen
+            .Setup(g => g.GenerateAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<EmbeddingGenerationOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeEmbeddings([0.2f]));
+        _mockClient.Setup(c => c.GetBookAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BookWithContents { Id = 1, Slug = "test-book" });
+        _mockStore.Setup(s => s.UpsertAsync(It.IsAny<VectorPageEntry>(), It.IsAny<ReadOnlyMemory<float>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var cycleDone = WireSetLastSyncAt();
+
+        using var service = CreateService();
+        await service.StartAsync(CancellationToken.None).ConfigureAwait(false);
+        await cycleDone.Task.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+        await service.StopAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var expectedHash = ComputeHash(html);
+        _mockStore.Verify(
+            s => s.UpsertAsync(
+                It.Is<VectorPageEntry>(e => e.ContentHash == expectedHash && e.PageId == 11),
+                It.IsAny<ReadOnlyMemory<float>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // T27 — chunked path: IChunkingService called and UpsertAsync called once per chunk
+    [Test]
+    public async Task SyncPageAsync_ChunkingEnabled_UpsertCalledPerChunk()
+    {
+        const string html = "<p>Long content to chunk.</p>";
+        var chunkingOptions = Options.Create(new VectorSearchOptions
+        {
+            Enabled = true,
+            Sync = new VectorSyncOptions { IntervalHours = 10_000 },
+            Chunking = new ChunkOptions { ChunkSize = 512, ChunkOverlap = 128 },
+        });
+
+        var chunks = new List<TextChunk>
+        {
+            new("chunk one", 0, 2, 5),
+            new("chunk two", 1, 2, 4),
+        };
+
+        _mockChunkingService
+            .Setup(c => c.ChunkAsync(html, It.IsAny<ChunkOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunks);
+
+        _mockStore.Setup(s => s.GetLastSyncAtAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTimeOffset?)null);
+        _mockClient
+            .Setup(c => c.GetPagesUpdatedSinceAsync(It.IsAny<DateTimeOffset>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListResponse<Page>
+            {
+                Data = [new Page { Id = 20, BookId = 1, Name = "Chunked", Slug = "chunked" }],
+                Total = 1,
+            });
+        _mockClient.Setup(c => c.GetPageAsync(20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PageWithContent { Id = 20, Editor = "wysiwyg", Html = html });
+        _mockStore.Setup(s => s.GetContentHashAsync(20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        _mockStore.Setup(s => s.DeleteChunksAsync(20, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _mockEmbGen
+            .Setup(g => g.GenerateAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<EmbeddingGenerationOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeEmbeddings([0.3f]));
+        _mockClient.Setup(c => c.GetBookAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BookWithContents { Id = 1, Slug = "test-book" });
+        _mockStore.Setup(s => s.UpsertAsync(It.IsAny<VectorPageEntry>(), It.IsAny<ReadOnlyMemory<float>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var cycleDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _mockStore.Setup(s => s.SetLastSyncAtAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .Callback<DateTimeOffset, CancellationToken>((_, _) => cycleDone.TrySetResult())
+            .Returns(Task.CompletedTask);
+
+        VectorIndexSyncService chunkingService = new(
+            _mockStore.Object,
+            _mockEmbGen.Object,
+            _mockChunkingService.Object,
+            _mockClient.Object,
+            chunkingOptions,
+            _clientOptions,
+            NullLogger<VectorIndexSyncService>.Instance);
+
+        using var service = chunkingService;
+        await service.StartAsync(CancellationToken.None).ConfigureAwait(false);
+        await cycleDone.Task.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+        await service.StopAsync(CancellationToken.None).ConfigureAwait(false);
+
+        // One UpsertAsync call per chunk
+        _mockStore.Verify(
+            s => s.UpsertAsync(
+                It.Is<VectorPageEntry>(e => e.PageId == 20 && e.ChunkIndex == 0 && e.TotalChunks == 2),
+                It.IsAny<ReadOnlyMemory<float>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockStore.Verify(
+            s => s.UpsertAsync(
+                It.Is<VectorPageEntry>(e => e.PageId == 20 && e.ChunkIndex == 1 && e.TotalChunks == 2),
+                It.IsAny<ReadOnlyMemory<float>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // DeleteChunksAsync called once before upserts
+        _mockStore.Verify(
+            s => s.DeleteChunksAsync(20, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }


### PR DESCRIPTION
Closes #109

## Summary

Integrates the published `MarkZither.Rag.Chunking` NuGet package into `VectorIndexSyncService`, replacing the local project reference. Pages are now chunked before embedding, improving semantic search quality for long content.

## Changes

### `BookStack.Mcp.Server.csproj`
- Replaced `<ProjectReference>` to local `MarkZither.Rag.Chunking` with `<PackageReference Include="MarkZither.Rag.Chunking" Version="[0.0.1-alpha.1,0.1.0)" />`

### `VectorIndexSyncService.cs`
- Injected `IChunkingService` via constructor
- **Markdown preference** (Req 21): selects `page.Markdown` when `Editor == "markdown"` and non-empty; falls back to `page.Html`
- **DrawIO detection** (Req 20): logs `Warning` when `<mxGraphModel`, `data-drawio`, or `class="drawio"` appears in HTML
- Content hash is now computed from the selected input text (not always Html)
- **Chunking path** (Req 23/24): `ChunkSize > 0` → `IChunkingService.ChunkAsync` → `DeleteChunksAsync` → `UpsertAsync` per chunk with correct `ChunkIndex`/`TotalChunks`
- **Single-chunk fallback** (no regression): `ChunkSize == 0` retains original single-embedding behaviour

### `VectorSearchServiceCollectionExtensions.cs`
- Added `services.AddChunking()` in the `AddVectorSearch` enabled path

### `VectorIndexSyncServiceTests.cs`
- Added `Mock<IChunkingService>` and updated `CreateService()`
- Shared `_options` set `ChunkSize = 0` so existing tests (T21–T24) continue exercising the single-chunk path
- **T25**: markdown preference — hash and embedding use Markdown text
- **T26**: HTML fallback — non-markdown editor uses Html
- **T27**: chunked path — `UpsertAsync` called per chunk with correct `ChunkIndex`/`TotalChunks`, `DeleteChunksAsync` called once

## Test results

153 tests, 0 failed, 0 skipped.