### PR TITLE
ci(#115): replace GuardRails with Dependency Review, SonarCloud, and Codecov

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,19 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: nuget
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: npm
+    directory: /vscode-extension
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,19 +29,21 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --configuration Release
 
-      - name: Test
-        run: >
-          dotnet test
-          --project tests/BookStack.Mcp.Server.Tests/BookStack.Mcp.Server.Tests.csproj
-          --no-build --configuration Release
-          --collect:"XPlat Code Coverage"
-          --results-directory coverage
+      - name: Install dotnet-coverage
+        run: dotnet tool install --global dotnet-coverage
+
+      - name: Test with coverage
+        run: |
+          dotnet-coverage collect \
+            "dotnet test --project tests/BookStack.Mcp.Server.Tests/BookStack.Mcp.Server.Tests.csproj --no-build --configuration Release" \
+            --output coverage/coverage.cobertura.xml \
+            --output-format cobertura
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: coverage
+          files: coverage/coverage.cobertura.xml
           fail_ci_if_error: false
 
       - name: Format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
 
       - name: Test
         run: >
-          dotnet test tests/BookStack.Mcp.Server.Tests/BookStack.Mcp.Server.Tests.csproj
+          dotnet test
+          --project tests/BookStack.Mcp.Server.Tests/BookStack.Mcp.Server.Tests.csproj
           --no-build --configuration Release
           --collect:"XPlat Code Coverage"
           --results-directory coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Test
         run: >
-          dotnet test --project tests/BookStack.Mcp.Server.Tests
+          dotnet test tests/BookStack.Mcp.Server.Tests/BookStack.Mcp.Server.Tests.csproj
           --no-build --configuration Release
           --collect:"XPlat Code Coverage"
           --results-directory coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write # required for Codecov PR comment
 
 jobs:
   build:
@@ -29,7 +30,17 @@ jobs:
         run: dotnet build --no-restore --configuration Release
 
       - name: Test
-        run: dotnet test --no-build --configuration Release
+        run: >
+          dotnet test --no-build --configuration Release
+          --collect:"XPlat Code Coverage"
+          --results-directory coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: coverage
+          fail_ci_if_error: false
 
       - name: Format
         run: dotnet format --verify-no-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
 
       - name: Test
         run: >
-          dotnet test --no-build --configuration Release
+          dotnet test --project tests/BookStack.Mcp.Server.Tests
+          --no-build --configuration Release
           --collect:"XPlat Code Coverage"
           --results-directory coverage
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,21 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/dependency-review-action@da24cf5f1afa91a0d7b35ac8f8cc45dbcf1ed2a1 # v4
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: always

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/dependency-review-action@da24cf5f1afa91a0d7b35ac8f8cc45dbcf1ed2a1 # v4
+      - uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: moderate
           comment-summary-in-pr: always

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -49,7 +49,8 @@ jobs:
 
       - name: Test with coverage
         run: >
-          dotnet test --no-build --configuration Release
+          dotnet test --project tests/BookStack.Mcp.Server.Tests
+          --no-build --configuration Release
           --collect:"XPlat Code Coverage;Format=opencover"
           --results-directory coverage
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -49,7 +49,8 @@ jobs:
 
       - name: Test with coverage
         run: >
-          dotnet test tests/BookStack.Mcp.Server.Tests/BookStack.Mcp.Server.Tests.csproj
+          dotnet test
+          --project tests/BookStack.Mcp.Server.Tests/BookStack.Mcp.Server.Tests.csproj
           --no-build --configuration Release
           --collect:"XPlat Code Coverage;Format=opencover"
           --results-directory coverage

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           dotnet sonarscanner begin \
             /k:"MarkZither_bookstack-mcp-server-dotnet" \
-            /o:"markzither" \
+            /o:"markzither-github" \
             /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
             /d:sonar.host.url="https://sonarcloud.io" \
             /d:sonar.cs.opencover.reportsPaths="**/coverage/**.xml" \
@@ -49,7 +49,7 @@ jobs:
 
       - name: Test with coverage
         run: >
-          dotnet test --project tests/BookStack.Mcp.Server.Tests
+          dotnet test tests/BookStack.Mcp.Server.Tests/BookStack.Mcp.Server.Tests.csproj
           --no-build --configuration Release
           --collect:"XPlat Code Coverage;Format=opencover"
           --results-directory coverage

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -23,8 +23,10 @@ jobs:
         with:
           global-json-file: global.json
 
-      - name: Install SonarCloud scanner
-        run: dotnet tool install --global dotnet-sonarscanner
+      - name: Install tools
+        run: |
+          dotnet tool install --global dotnet-sonarscanner
+          dotnet tool install --global dotnet-coverage
 
       - name: Restore
         run: dotnet restore
@@ -41,19 +43,18 @@ jobs:
             /o:"markzither-github" \
             /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
             /d:sonar.host.url="https://sonarcloud.io" \
-            /d:sonar.cs.opencover.reportsPaths="**/coverage/**.xml" \
+            /d:sonar.cs.vscoveragexml.reportsPaths="coverage/coverage.xml" \
             /d:sonar.exclusions="**/Migrations/**,**/obj/**,**/bin/**"
 
       - name: Build
         run: dotnet build --no-restore --configuration Release
 
       - name: Test with coverage
-        run: >
-          dotnet test
-          --project tests/BookStack.Mcp.Server.Tests/BookStack.Mcp.Server.Tests.csproj
-          --no-build --configuration Release
-          --collect:"XPlat Code Coverage;Format=opencover"
-          --results-directory coverage
+        run: |
+          dotnet-coverage collect \
+            "dotnet test --project tests/BookStack.Mcp.Server.Tests/BookStack.Mcp.Server.Tests.csproj --no-build --configuration Release" \
+            --output coverage/coverage.xml \
+            --output-format xml
 
       - name: End SonarCloud analysis
         env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,59 @@
+name: SonarCloud
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sonarcloud:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0 # full history required for blame / new-code detection
+
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          global-json-file: global.json
+
+      - name: Install SonarCloud scanner
+        run: dotnet tool install --global dotnet-sonarscanner
+
+      - name: Restore
+        run: dotnet restore
+        env:
+          HUSKY: 0
+
+      - name: Begin SonarCloud analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dotnet sonarscanner begin \
+            /k:"MarkZither_bookstack-mcp-server-dotnet" \
+            /o:"markzither" \
+            /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
+            /d:sonar.host.url="https://sonarcloud.io" \
+            /d:sonar.cs.opencover.reportsPaths="**/coverage/**.xml" \
+            /d:sonar.exclusions="**/Migrations/**,**/obj/**,**/bin/**"
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Test with coverage
+        run: >
+          dotnet test --no-build --configuration Release
+          --collect:"XPlat Code Coverage;Format=opencover"
+          --results-directory coverage
+
+      - name: End SonarCloud analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
Closes #115

## Summary

Replaces the unreliable GuardRails free-tier check with three purpose-built tools that work reliably for open source projects.

## Changes

### `dependabot.yml` (fixed)
- Was: bare template with empty `package-ecosystem`
- Now: enables **nuget**, **npm** (`/vscode-extension`), and **github-actions** ecosystems on a weekly schedule

### `.github/workflows/dependency-review.yml` (new)
- Runs on every PR to `main`
- Uses `actions/dependency-review-action` — blocks merge on **moderate+** severity vulnerabilities
- Posts a summary comment on the PR automatically

### `.github/workflows/sonarcloud.yml` (new)
- Runs on push to `main` and on PRs
- Uses `dotnet-sonarscanner` with opencover coverage reports
- Requires secret: **`SONAR_TOKEN`** — get from https://sonarcloud.io → project → Administration → Security
- Project key: `MarkZither_bookstack-mcp-server-dotnet`, org: `markzither`

### `.github/workflows/ci.yml` (updated)
- Test step now collects **XPlat Code Coverage**
- New step uploads coverage to **Codecov** via `codecov/codecov-action@v5`
- Requires secret: **`CODECOV_TOKEN`** — get from https://app.codecov.io → repository settings
- `fail_ci_if_error: false` so a Codecov outage won't block merges

## Post-merge steps

1. Add `SONAR_TOKEN` repository secret
2. Add `CODECOV_TOKEN` repository secret
3. **Revoke the GuardRails GitHub App** from repository Settings → Integrations → GitHub Apps to stop the `guardrails/scan` check appearing on PRs

## Note: 3 existing vulnerabilities found

GitHub flagged 2 high + 1 moderate vulnerabilities on `main` when this branch was pushed. Check https://github.com/MarkZither/bookstack-mcp-server-dotnet/security/dependabot — Dependabot PRs should arrive shortly now that the config is fixed.