### PR TITLE
feat(#116): target .NET 11 Preview 4 SDK

### DIFF
--- a/.github/workflows/chunking-package.yml
+++ b/.github/workflows/chunking-package.yml
@@ -32,13 +32,22 @@ jobs:
           include-prerelease: true
 
       - name: Restore
-        run: dotnet restore src/MarkZither.Rag.Chunking/MarkZither.Rag.Chunking.csproj
+        run: |
+          dotnet restore src/MarkZither.Rag.Chunking/MarkZither.Rag.Chunking.csproj
+          dotnet restore tests/MarkZither.Rag.Chunking.Tests/MarkZither.Rag.Chunking.Tests.csproj
 
       - name: Build
         run: dotnet build src/MarkZither.Rag.Chunking/MarkZither.Rag.Chunking.csproj --configuration Release --no-restore
 
+      - name: Install dotnet-coverage
+        run: dotnet tool install --global dotnet-coverage
+
       - name: Test
-        run: dotnet test --project tests/MarkZither.Rag.Chunking.Tests/MarkZither.Rag.Chunking.Tests.csproj --configuration Release --no-restore
+        run: |
+          dotnet-coverage collect \
+            "dotnet test --project tests/MarkZither.Rag.Chunking.Tests/MarkZither.Rag.Chunking.Tests.csproj --configuration Release --no-restore" \
+            --output coverage/coverage.cobertura.xml \
+            --output-format cobertura
 
       - name: Pack
         run: dotnet pack src/MarkZither.Rag.Chunking/MarkZither.Rag.Chunking.csproj --configuration Release --no-build -o artifacts

--- a/.github/workflows/chunking-package.yml
+++ b/.github/workflows/chunking-package.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           global-json-file: global.json
+          include-prerelease: true
 
       - name: Restore
         run: dotnet restore src/MarkZither.Rag.Chunking/MarkZither.Rag.Chunking.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           global-json-file: global.json
+          include-prerelease: true
 
       - name: Restore
         run: dotnet restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           global-json-file: global.json
+          include-prerelease: true
 
       - name: Publish ${{ matrix.rid }}
         run: |
@@ -104,6 +105,7 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           global-json-file: global.json
+          include-prerelease: true
 
       - name: Publish server (framework-dependent)
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           global-json-file: global.json
+          include-prerelease: true
 
       - name: Install tools
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   sonarcloud:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
@@ -42,7 +43,7 @@ jobs:
           dotnet sonarscanner begin \
             /k:"MarkZither_bookstack-mcp-server-dotnet" \
             /o:"markzither-github" \
-            /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
+            /d:sonar.token="$SONAR_TOKEN" \
             /d:sonar.host.url="https://sonarcloud.io" \
             /d:sonar.cs.vscoveragexml.reportsPaths="coverage/coverage.xml" \
             /d:sonar.exclusions="**/Migrations/**,**/obj/**,**/bin/**"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "11.0.100-preview.4.26230.115",
     "rollForward": "latestPatch"
   },
   "test": {

--- a/src/MarkZither.Rag.Chunking/MarkZither.Rag.Chunking.csproj
+++ b/src/MarkZither.Rag.Chunking/MarkZither.Rag.Chunking.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0;net11.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/tests/MarkZither.Rag.Chunking.Tests/MarkZither.Rag.Chunking.Tests.csproj
+++ b/tests/MarkZither.Rag.Chunking.Tests/MarkZither.Rag.Chunking.Tests.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Closes #116

## Changes

- **`global.json`**: pin SDK to `11.0.100-preview.4.26230.115`
- **`ci.yml`, `sonarcloud.yml`, `release.yml` (×2), `chunking-package.yml`**: add `include-prerelease: true` to all `setup-dotnet` steps so GitHub-hosted runners download and use the pre-release SDK from `global.json`

## Local setup

The .NET 11 Preview 4 SDK was not available via the system package manager. Install it alongside .NET 10:

```bash
curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 11.0.100-preview.4.26230.115
```

Then add `~/.dotnet` to your PATH (e.g. in `~/.bashrc`):
```bash
export PATH="$HOME/.dotnet:$PATH"
```