### PR TITLE
fix(sqlite): positional VectorStoreVector for VectorData 10.6.0

### DIFF
--- a/src/BookStack.Mcp.Server.Data.Sqlite/VectorPageRecord.cs
+++ b/src/BookStack.Mcp.Server.Data.Sqlite/VectorPageRecord.cs
@@ -34,6 +34,6 @@ public sealed class VectorPageRecord
     [VectorStoreData]
     public string ContentHash { get; set; } = string.Empty;
 
-    [VectorStoreVector(Dimensions: 1024)]
+    [VectorStoreVector(1024)]
     public ReadOnlyMemory<float> Embedding { get; set; }
 }


### PR DESCRIPTION
VectorData.Abstractions 10.6.0 removed the `Dimensions` named parameter from `VectorStoreVectorAttribute`. Use the positional form `[VectorStoreVector(1024)]` instead.