### PR TITLE
chore: v0.5.1 — fix retired VS Code Marketplace badge, bump dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           global-json-file: global.json
-          include-prerelease: true
 
       - name: Publish ${{ matrix.rid }}
         run: |
@@ -105,7 +104,6 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           global-json-file: global.json
-          include-prerelease: true
 
       - name: Publish server (framework-dependent)
         run: |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # bookstack-mcp-server-dotnet
 
 [![CI](https://github.com/MarkZither/bookstack-mcp-server-dotnet/actions/workflows/ci.yml/badge.svg)](https://github.com/MarkZither/bookstack-mcp-server-dotnet/actions/workflows/ci.yml)
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/MarkZither.bookstack-mcp-server.svg?label=VS%20Code%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=MarkZither.bookstack-mcp-server)
+[![VS Code Marketplace](https://img.shields.io/vscode-marketplace/v/MarkZither.bookstack-mcp-server.svg?label=VS%20Code%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=MarkZither.bookstack-mcp-server)
 [![Docker Pulls](https://img.shields.io/docker/pulls/markzither/bookstack-mcp-server.svg)](https://hub.docker.com/r/markzither/bookstack-mcp-server)
 [![Docker Image Version](https://img.shields.io/docker/v/markzither/bookstack-mcp-server/latest?label=docker)](https://hub.docker.com/r/markzither/bookstack-mcp-server)
 

--- a/src/BookStack.Mcp.Server.Data.Postgres/BookStack.Mcp.Server.Data.Postgres.csproj
+++ b/src/BookStack.Mcp.Server.Data.Postgres/BookStack.Mcp.Server.Data.Postgres.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="10.0.2" />
+    <PackageReference Include="Npgsql" Version="10.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.*" />
     <PackageReference Include="Pgvector" Version="0.3.2" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-05-28
+
+### Fixed
+
+- **README badge** — replaced retired `visual-studio-marketplace` shields.io category with
+  the current `vscode-marketplace` category so the version badge renders correctly.
+
+### Changed
+
+- **Tiktoken** updated from 2.0.3 to 3.1.5.
+- **FluentAssertions** (test dependency) updated from 7.2.2 to 8.10.0.
+
 ## [0.5.0] - 2026-05-26
 
 ### Added

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "bookstack-mcp-server",
   "displayName": "BookStack MCP Server",
   "description": "MCP server for BookStack — gives AI assistants (GitHub Copilot, Claude) access to your BookStack knowledge base.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publisher": "MarkZither",
   "engines": {
     "vscode": "^1.120.0"


### PR DESCRIPTION
## v0.5.1

### Fixed
- Replace retired `visual-studio-marketplace` shields.io badge with `vscode-marketplace` so the version badge renders correctly in the README.

### Changed
- Tiktoken 2.0.3 → 3.1.5 (via Dependabot #147, already merged to main)
- FluentAssertions 7.2.2 → 8.10.0 (via Dependabot #137, already merged to main)

The `v0.5.1` tag has already been pushed and the release workflow is running.